### PR TITLE
[Feature] Protección de rutas administrativas con authGuard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,7 +18,7 @@ export const routes: Routes = [
     loadChildren: () => import('./features/user/user.routes').then(m => m.USER_ROUTES)
     },
     {
-    path: 'genres',
+    path: 'admin/genres',
     canActivate: [authGuard],
     loadChildren: () => import('./features/genre/genre.routes').then(m => m.GENRE_ROUTES)
     },

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -4,6 +4,9 @@ import { Router, type CanActivateFn } from '@angular/router';
 export const authGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
   const token = localStorage.getItem('token');
+  const authString = localStorage.getItem('auth');
+  const auth = authString ? JSON.parse(authString) : null;
+  const rolename = auth?.user?.roleName;
 
   // Si estamos en una ruta de auth (login/register) y hay token, redirigir al dashboard
   if (state.url.startsWith('/auth') && token) {
@@ -14,6 +17,11 @@ export const authGuard: CanActivateFn = (route, state) => {
   // Si estamos en una ruta protegida y no hay token, redirigir al login
   if (!state.url.startsWith('/auth') && !token) {
     router.navigate(['/auth/login']);
+    return false;
+  }
+
+  if(state.url.startsWith('/admin') && token && rolename !== 'ADMIN') {
+    router.navigate(['/home']);
     return false;
   }
 


### PR DESCRIPTION
- Se implementó lógica en authGuard para permitir acceso a rutas bajo '/admin' únicamente a usuarios con rol ADMIN.
- Se añadió redirección automática a '/home' para usuarios autenticados sin permisos de administrador que intenten acceder a rutas restringidas.
- El CRUD de géneros ahora solo es accesible para admins, manteniendo el componente selector de géneros reutilizable en otros módulos.
