### PR TITLE
[Feature] [US14, US15, US28] Refactor y mejoras en CRUD de géneros musicales

### DIFF
--- a/src/app/features/genre/genre.routes.ts
+++ b/src/app/features/genre/genre.routes.ts
@@ -1,9 +1,14 @@
 import { TestListGenreComponent } from "./pages/test_genre/test-list-genre.component";
 import { Routes } from "@angular/router";
+import { GenreComponent } from "./pages/crud_genre/genre.component";
 
 export const GENRE_ROUTES: Routes = [
   {
-    path: '',
+    path: 'test',
     loadComponent: () => import('./pages/test_genre/test-list-genre.component').then(m => m.TestListGenreComponent)
+  },
+  {
+    path: '',
+    loadComponent: () => import('./pages/crud_genre/genre.component').then(m => m.GenreComponent)
   }
 ];

--- a/src/app/features/genre/pages/crud_genre/genre.component.css
+++ b/src/app/features/genre/pages/crud_genre/genre.component.css
@@ -1,0 +1,170 @@
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@500&display=swap');
+
+* {
+  font-family: 'Manrope', 'Arial', sans-serif;
+}
+
+h2 {
+  color: #A81919;
+  font-size: 28px;
+  margin-top: 32px;
+  margin-bottom: 10px;
+  font-weight: 600;
+}
+
+label {
+  color: #FFFFFF;
+  font-size: 18px;
+  font-weight: 500;
+  margin-top: 12px;
+  margin-bottom: 6px;
+  display: block;
+}
+
+form, .form-card {
+  background: #A81919;
+  border-radius: 10px;
+  padding: 30px 28px 20px 28px;
+  margin-bottom: 32px;
+  box-shadow: 0 2px 8px 0 rgba(0,0,0,0.09);
+  max-width: 500px;
+  width: 100%;
+}
+
+select {
+  background: #F3F3F3;
+  border: 1.5px solid #A81919;
+  color: black;
+  font-size: 18px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  max-width: 500px; ;
+  width: 100%;
+  margin-bottom: 16px;
+  outline: none;
+}
+input {
+  font-family: 'Manrope', 'Arial', sans-serif;
+  font-size: 18px;
+  border-radius: 6px;
+  border: none;
+  padding: 8px 12px;
+  margin-bottom: 16px;
+  background: #FFFFFF;
+  color: black;
+  width: 100%;
+  outline: none;
+  box-sizing: border-box;
+}
+
+input:focus {
+  border: 2px solid #A81919;
+  background: #FFFFFF;
+}
+
+select:focus {
+  border: 2px solid #D80000;
+  background: #FFFFFF;
+}
+
+button[type="submit"] {
+  background: #FFFFFF;
+  color: #D80000;
+  font-weight: 600;
+  font-size: 20px;
+  border: none;
+  border-radius: 6px;
+  padding: 10px 20px;
+  margin-top: 8px;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+button[type="submit"]:hover {
+  background: #D80000;
+  color: #FFFFFF;
+  border: 1.5px solid #FFF3EA;
+}
+
+/* --- Feedback y errores --- */
+.error, .editError, .createError, .deleteError {
+  color: #D32F2F;           
+  background: #FDECEA;      
+  border: 1px solid #F44336;  
+  padding: 7px 14px;
+  border-radius: 5px;
+  font-size: 16px;
+  margin: 8px 0 4px 0;
+  font-weight: 500;
+}
+
+.createSuccess, .editSuccess, .deleteSuccess {
+  color: #36FF8B;
+  background: #184b28;
+  padding: 7px 14px;
+  border-radius: 4px;
+  font-size: 16px;
+  margin: 8px 0 4px 0;
+}
+
+ul.genre-list {
+  background: #FFFFFF;
+  border-radius: 8px;
+  padding: 20px 25px;
+  box-shadow: 0 1px 8px rgba(0,0,0,0.09);
+  margin-bottom: 32px;
+  list-style: disc inside;
+}
+
+ul.genre-list li {
+  font-size: 20px;
+  color: #A81919;
+  margin-bottom: 8px;
+  font-weight: 500;
+  padding: 7px 0 7px 12px;
+  border-bottom: 1px solid #a8191955;
+}
+
+ul.genre-list li:last-child {
+  border-bottom: none;
+}
+
+.admin-center-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;     
+  justify-content: center; 
+  padding: 32px 0;
+  background: #f7f7f7;     
+}
+
+.form-card, form {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+ul.genre-list {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.delete-btn {
+  background: #D80000;
+  color: #FFF3EA;
+  font-weight: bold;
+  border: none;
+  border-radius: 6px;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+  margin-top: 12px;
+}
+.delete-btn:hover {
+  background: #a81919;
+  color: #FFF3EA;
+}
+
+.label-red {
+  color: #D80000;
+  font-weight: 600;
+}

--- a/src/app/features/genre/pages/crud_genre/genre.component.html
+++ b/src/app/features/genre/pages/crud_genre/genre.component.html
@@ -1,41 +1,42 @@
+<div class="admin-center-container">
 <h2>Lista de Géneros Musicales</h2>
 
 <div *ngIf="error" class="error">{{ error }}</div>
 
-<ul>
+<ul class="genre-list">
   <li *ngFor="let genre of genres">
     {{ genre.name }} - {{ genre.description }}
   </li>
 </ul>
 
-<!-- Formulario para crear género -->
+
 <h2>Crear Género Musical</h2>
-<form (ngSubmit)="onCreateGenre()" #genreForm="ngForm">
+<form class="form-card" (ngSubmit)="onCreateGenre()" #genreForm="ngForm">
   <label for="name">Nombre del género:</label>
   <input type="text" id="name" name="name" [(ngModel)]="newGenre.name" #name="ngModel" required minlength="3">
-  <div *ngIf="name.invalid && name.touched" style="color:red;">
+  <div *ngIf="name.invalid && (name.dirty || name.touched)" class="error">
   <span *ngIf="name.errors?.['required']">El nombre es obligatorio.</span>
   <span *ngIf="name.errors?.['minlength']">El nombre debe tener al menos 3 caracteres.</span>
 </div>
   <label for="description">Descripción (opcional):</label>
   <input type="text" id="description" name="description" [(ngModel)]="newGenre.description" #desc="ngModel" maxlength="200">
-  <div *ngIf="desc.errors?.['maxlength'] && desc.touched" style="color:red;">
+  <div *ngIf="desc.errors?.['maxlength'] && desc.touched" class="error">
     La descripción no puede exceder los 200 caracteres.
   </div>
   <button type="submit">Crear género</button>
 </form>
 
-<!-- Feedback -->
-<div *ngIf="createSuccess" style="color: green;">
+
+<div *ngIf="createSuccess" class="createSuccess">
   Género creado exitosamente.
 </div>
-<div *ngIf="createError" style="color: red;">
-  {{ createError }}
+<div *ngIf="createError" class="createError">
+  ⚠️ {{ createError }}
 </div>
 
-<!-- Dropdown para seleccionar el género a editar -->
+
 <h2>Editar Género Musical</h2>
-<label for="genreSelect">Selecciona un género para editar:</label>
+<label class = "label-red" for="genreSelect">Selecciona un género para editar:</label>
 <select id="genreSelect" [(ngModel)]="selectedGenreId" (change)="onSelectGenre()" name="genreSelect">
   <option [ngValue]="null">-- Selecciona un género --</option>
   <option *ngFor="let genre of genres" [ngValue]="genre.id">
@@ -43,33 +44,33 @@
   </option>
 </select>
 
-<!-- Formulario de edición solo si hay uno seleccionado -->
-<form *ngIf="editingGenre" (ngSubmit)="onUpdateGenre()" #editForm="ngForm">
+
+<form class = "form-card" *ngIf="editingGenre" (ngSubmit)="onUpdateGenre()" #editForm="ngForm">
   <label for="editName">Nombre del género:</label>
   <input type="text" id="editName" name="editName" [(ngModel)]="editingGenre.name" #editName="ngModel" required minlength="3">
-  <div *ngIf="editName.invalid && editName.touched" style="color:red;">
+  <div *ngIf="editName.invalid && (editName.dirty || editName.touched)" class="error">
     <span *ngIf="editName.errors?.['required']">El nombre es obligatorio.</span>
     <span *ngIf="editName.errors?.['minlength']">El nombre debe tener al menos 3 caracteres.</span>
   </div>
   <label for="editDescription">Descripción (opcional):</label>
   <input type="text" id="editDescription" name="editDescription" [(ngModel)]="editingGenre.description" #editDesc="ngModel" maxlength="200">
-  <div *ngIf="editDesc.errors?.['maxlength'] && editDesc.touched" style="color:red;">
+  <div *ngIf="editDesc.errors?.['maxlength'] && (editDesc.dirty || editDesc.touched)" class="error">
     La descripción no puede exceder 200 caracteres.
   </div>
   <button type="submit">Actualizar género</button>
 </form>
 
-<!-- Feedback edición -->
-<div *ngIf="editSuccess" style="color: green;">
+
+<div *ngIf="editSuccess" class="editSuccess">
   Género actualizado exitosamente.
 </div>
-<div *ngIf="editError" style="color: red;">
-  {{ editError }}
+<div *ngIf="editError" class="editError">
+  ⚠️ {{ editError }}
 </div>
 
-<!-- Dropdown para seleccionar género a borrar -->
+
 <h2>Eliminar Género Musical</h2>
-<label for="genreDeleteSelect">Selecciona un género para eliminar:</label>
+<label class = "label-red" for="genreDeleteSelect">Selecciona un género para eliminar:</label>
 <select id="genreDeleteSelect" [(ngModel)]="selectedDeleteGenreId" name="genreDeleteSelect">
   <option [ngValue]="null">-- Selecciona un género --</option>
   <option *ngFor="let genre of genres" [ngValue]="genre.id">
@@ -77,18 +78,18 @@
   </option>
 </select>
 
-<!-- Botón de eliminar solo si hay uno seleccionado -->
-<form *ngIf="selectedDeleteGenreId" (ngSubmit)="onDeleteGenre()" #deleteForm="ngForm">
-  <button type="submit" style="color:red;">Eliminar género</button>
-</form>
 
-<!-- Feedback de borrado -->
-<div *ngIf="deleteSuccess" style="color: green;">
+<button  *ngIf="selectedDeleteGenreId" type="button" class="delete-btn" (click)="onDeleteGenre()" >
+  Eliminar género
+</button>
+
+
+<div *ngIf="deleteSuccess" class="deleteSuccess">
   Género eliminado exitosamente.
 </div>
-<div *ngIf="deleteError" style="color: red;">
-  {{ deleteError }}
+<div *ngIf="deleteError" class="deleteError">
+  ⚠️ {{ deleteError }}
 </div>
-
+</div>
 
 

--- a/src/app/features/genre/pages/crud_genre/genre.component.ts
+++ b/src/app/features/genre/pages/crud_genre/genre.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { GenreService } from '../../../../services/genre.service';
 import { GenreRequest, GenreResponse } from '../../../../models/genre.model';
 import { NgFor, NgIf } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, NgForm } from '@angular/forms';
 @Component({
   selector: 'app-genre',
   imports: [NgIf,NgFor, FormsModule],
@@ -10,6 +10,7 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './genre.component.css'
 })
 export class GenreComponent implements OnInit{
+  @ViewChild('genreForm') genreForm!: NgForm; 
   genres: GenreResponse[] = [];
   error: string = '';
   newGenre: GenreRequest = { name: '', description: '' };
@@ -22,6 +23,7 @@ export class GenreComponent implements OnInit{
   selectedDeleteGenreId: number | null = null;
   deleteSuccess = false;
   deleteError = '';
+ 
 
 
   constructor(private genreService: GenreService) {}
@@ -55,19 +57,26 @@ export class GenreComponent implements OnInit{
     this.genreService.create_genre(this.newGenre).subscribe({
       next: (res) => {
         this.createSuccess = true;
-        this.newGenre = { name: '', description: '' }; // Limpia el form
-        this.loadGenres(); // Recarga la lista
-      },
+        this.newGenre = { name: '', description: '' }; 
+        this.loadGenres(); 
+        setTimeout(() => {
+          this.genreForm.resetForm();
+        });
+        setTimeout(() => {
+          this.createSuccess = false; 
+        }
+        , 2000); 
+    },
       error: (err) => {
-        this.createError = err?.error?.message || 'Error al crear el género';
+        this.createError = err?.error?.detail || 'Error al crear el género';
       }
     });
   }
 
   onSelectGenre(): void {
-    // Busca el género seleccionado en la lista
+
     const genre = this.genres.find(g => g.id === this.selectedGenreId);
-    // Precarga los datos en el form de edición (haz una copia para no mutar el original)
+
     if (genre) {
       this.editingGenre = { name: genre.name, description: genre.description };
       this.editSuccess = false;
@@ -83,10 +92,16 @@ onUpdateGenre(): void {
     next: (res) => {
       this.editSuccess = true;
       this.editError = '';
-      this.loadGenres(); // refresca la lista
+      this.loadGenres(); 
+      setTimeout(() => {
+        this.editSuccess = false; 
+        this.editingGenre = null; 
+        this.selectedGenreId = null; 
+      }
+      , 2000);
     },
     error: (err) => {
-      this.editError = err?.error?.message || 'Error al actualizar el género';
+      this.editError = err?.error?.detail || 'Error al actualizar el género';
       this.editSuccess = false;
     }
   });
@@ -99,11 +114,14 @@ onDeleteGenre(): void {
     next: () => {
       this.deleteSuccess = true;
       this.deleteError = '';
-      this.selectedDeleteGenreId = null; // Limpia la selección
+      this.selectedDeleteGenreId = null; 
       this.loadGenres();
+      setTimeout(() => {
+        this.deleteSuccess = false; 
+      }, 2000);
     },
     error: (err) => {
-      this.deleteError = err?.error?.message || 'Error al eliminar el género';
+      this.deleteError = err?.error?.detail || 'Error al eliminar el género';
       this.deleteSuccess = false;
     }
   });


### PR DESCRIPTION
- Unificación de las funcionalidades de creación, edición y eliminación de géneros musicales en un solo componente para una gestión centralizada y mantenible.
- Implementación de feedback visual consistente para mensajes de éxito y error, incluyendo reset automático y ocultamiento tras unos segundos.
- Refactorización del código HTML y CSS para eliminar estilos inline, usando clases reutilizables para feedback y validaciones.
- Integración de protección de rutas: sólo los usuarios con rol ADMIN pueden acceder al CRUD de géneros.
- Rutas actualizadas: el acceso por defecto a géneros apunta ahora al componente CRUD principal; se añadió ruta de test para pruebas del componente selector.
- Componente `<app-list-genres>` se mantiene reusable para otros formularios (ej. creación de álbumes).
- Mejoras UX: los formularios se resetean correctamente tras operaciones exitosas y los errores se limpian al interactuar de nuevo.

---


