### PR TITLE
[Refactor] Integración de gestión de canciones en perfil de artista (HU30)

### DIFF
--- a/src/app/features/album/album.routes.ts
+++ b/src/app/features/album/album.routes.ts
@@ -1,0 +1,26 @@
+import { Routes } from '@angular/router';
+// Importa los componentes cuando los crees en ./pages
+// import { AlbumListPageComponent } from './pages/album-list-page/album-list-page.component';
+// import { AlbumDetailPageComponent } from './pages/album-detail-page/album-detail-page.component';
+// import { AlbumCreatePageComponent } from './pages/album-create-page/album-create-page.component';
+// import { AlbumEditPageComponent } from './pages/album-edit-page/album-edit-page.component';
+
+export const ALBUM_ROUTES: Routes = [
+  {
+    path: '',
+    // component: AlbumListPageComponent // Listar todos los álbumes
+  },
+  {
+    path: 'create',
+    // component: AlbumCreatePageComponent // Crear álbum
+  },
+  {
+    path: ':id',
+    // component: AlbumDetailPageComponent // Ver detalle del álbum
+  },
+  {
+    path: ':id/edit',
+    // component: AlbumEditPageComponent // Editar álbum
+  }
+  // Puedes agregar más rutas según lo necesites
+];

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.css
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.css
@@ -1,0 +1,126 @@
+.albums-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: flex-start;
+}
+
+.album-card {
+  width: 220px;
+  background-color: white;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.14);
+  padding: 10px;
+  box-sizing: border-box;
+  text-align: left;
+  position: relative;
+  border-radius: 10px;
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.album-image {
+  width: 100%;
+  height: 0;
+  padding-top: 100%; /* Cuadrado */
+  background-color: #bbb;
+  background-size: cover;
+  background-position: center;
+  border-radius: 7px;
+}
+
+.album-info {
+  margin-top: 12px;
+}
+
+.album-name {
+  font-size: 16px;
+  font-weight: 500;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.album-owner {
+  color: #666;
+  font-size: 13px;
+  margin-top: 3px;
+}
+
+.dots {
+  display: flex;
+  gap: 4px;
+  justify-content: flex-start;
+  margin-top: 2px;
+  margin-left: 0;
+  cursor: pointer;
+  align-items: center;
+}
+.dots span {
+  width: 5px;
+  height: 5px;
+  background-color: #888;
+  border-radius: 50%;
+  display: inline-block;
+  transition: background 0.2s;
+}
+.dots:hover span {
+  background-color: #b71c1c;
+}
+
+.dropdown-menu {
+  position: absolute;
+  left: 0;
+  top: 100%;
+  margin-top: 4px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.13);
+  z-index: 100;
+  min-width: 130px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0;
+}
+.dropdown-menu button {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px 16px;
+  font-size: 15px;
+  color: #222;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.2s, color 0.2s;
+}
+.dropdown-menu button:hover {
+  background: #f5f5f5;
+  color: #b71c1c;
+}
+
+
+.play-button {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  width: 38px;
+  height: 38px;
+  background-color: #b71c1c;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.17);
+  cursor: pointer;
+}
+
+.play-button::before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 11px solid white;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  margin-left: 2px;
+}

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.html
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.html
@@ -1,0 +1,32 @@
+<div class="albums-list-container">
+  <ng-container *ngIf="isLoading">
+    <p>Cargando álbumes...</p>
+  </ng-container>
+  <ng-container *ngIf="error">
+    <p>{{ error }}</p>
+  </ng-container>
+  <ng-container *ngIf="!isLoading && !error && albums.length === 0">
+    <p>No hay álbumes para mostrar.</p>
+  </ng-container>
+  <ng-container *ngIf="!isLoading && !error && albums.length > 0">
+    <div class="albums-list">
+      <div class="album-card" *ngFor="let album of albums">
+        <div class="album-image" [ngStyle]="{ 'background-image': album.cover ? 'url(' + album.cover + ')' : '' }"></div>
+        <div class="album-info">
+          <p class="album-name">{{ album.title }}</p>
+          <p class="album-owner">{{ album.artistName }}</p>
+<div class="dots" (click)="toggleAlbumMenu(album)">
+  <span></span>
+  <span></span>
+  <span></span>
+</div>
+<div *ngIf="openMenuAlbumId === album.id" class="dropdown-menu">
+  <button (click)="editAlbum(album)">Editar Álbum</button>
+  <button (click)="confirmDeleteAlbum(album)">Eliminar Álbum</button>
+</div>
+        </div>
+        <div class="play-button"></div>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
@@ -1,0 +1,65 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { NgIf, NgFor, NgStyle } from '@angular/common';
+import { AlbumResponse } from '../../../../models/album.model';
+import { AlbumService } from '../../../../services/Album.service';
+
+@Component({
+  selector: 'app-artist-albums-list',
+  standalone: true,
+  imports: [NgIf, NgFor, NgStyle],
+  templateUrl: './artist-albums-list.component.html',
+  styleUrls: ['./artist-albums-list.component.css']
+})
+export class ArtistAlbumsListComponent implements OnInit {
+
+  openMenuAlbumId: number | null = null;
+
+  toggleAlbumMenu(album: any) {
+    this.openMenuAlbumId = this.openMenuAlbumId === album.id ? null : album.id;
+  }
+
+  editAlbum(album: any) {
+    // Aquí puedes abrir el modal de edición
+    console.log('Editar álbum:', album);
+    this.openMenuAlbumId = null;
+  }
+
+  confirmDeleteAlbum(album: any) {
+    // Aquí puedes mostrar un modal de confirmación
+    console.log('Eliminar álbum:', album);
+    this.openMenuAlbumId = null;
+  }
+
+
+  onAlbumDotsClick(album: any) {
+    // Aquí puedes abrir un menú contextual en el futuro
+    console.log('Dots click:', album);
+  }
+  @Input() artistId!: number;
+  albums: AlbumResponse[] = [];
+  isLoading = true;
+  error = '';
+
+  constructor(private albumService: AlbumService) {}
+
+  ngOnInit(): void {
+    this.fetchAlbums();
+  }
+
+  fetchAlbums(): void {
+    this.isLoading = true;
+    this.error = '';
+    // Si tu endpoint requiere el nombre del álbum, puedes pasar '' para traer todos
+    this.albumService.getAlbumsByTitleAndUser('').subscribe({
+      next: (res) => {
+        // Ajusta según la estructura real de la respuesta
+        this.albums = res.data || [];
+        this.isLoading = false;
+      },
+      error: (err) => {
+        this.error = 'Error al cargar los álbumes';
+        this.isLoading = false;
+      }
+    });
+  }
+}

--- a/src/app/features/album/components/create-album-modal/create-album-modal.component.css
+++ b/src/app/features/album/components/create-album-modal/create-album-modal.component.css
@@ -1,0 +1,247 @@
+.create-album-modal-backdrop {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.35);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.create-album-modal-container {
+  max-width: 700px;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 0 10px #ccc;
+  padding: 20px;
+  color: #333;
+  min-width: 350px;
+}
+.tabs {
+  display: flex;
+  gap: 20px;
+  font-weight: bold;
+  margin-bottom: 20px;
+}
+.tabs span {
+  cursor: pointer;
+  color: #888;
+}
+.tabs .active-tab {
+  color: red;
+  border-bottom: 3px solid red;
+  padding-bottom: 5px;
+}
+.tabs .disabled {
+  color: #888;
+  cursor: pointer;
+}
+.form-content {
+  display: flex;
+  gap: 20px;
+}
+.cover-preview {
+  width: 150px;
+  height: 150px;
+  background: linear-gradient(to top left, #d45b5b, #1a1a1a);
+  border-radius: 5px;
+}
+.form-fields {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+label {
+  font-size: 14px;
+}
+input[type="text"], select {
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  font-size: 14px;
+  background: #f4f4f4;
+}
+.cover-upload-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 18px;
+}
+.album-cover-preview {
+  width: 120px;
+  height: 120px;
+  border-radius: 12px;
+  background: #f4f4f4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+  overflow: hidden;
+  position: relative;
+  border: 1px solid #e0e0e0;
+}
+.album-cover-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
+.album-cover-preview.no-cover {
+  background: #e0e0e0;
+}
+.cover-placeholder {
+  font-size: 32px;
+  color: #bdbdbd;
+}
+.upload-cover-btn {
+  background: #b71c1c;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 7px 18px;
+  font-size: 14px;
+  cursor: pointer;
+  margin-bottom: 8px;
+  transition: background 0.2s;
+  display: inline-block;
+}
+.upload-cover-btn:hover {
+  background: #d32f2f;
+}
+.remove-cover-btn {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  background: rgba(183,28,28,0.85);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  padding: 3px 10px;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.2s;
+}
+.remove-cover-btn:hover {
+  background: #d32f2f;
+}
+
+.save-section {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 20px;
+  justify-content: space-between;
+}
+.save-button {
+  align-self: flex-end;
+  padding: 10px 30px;
+  background-color: red;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.save-button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+.cancel-button {
+  align-self: flex-start;
+  margin-top: 0;
+  background: transparent;
+  color: #b71c1c;
+  border: none;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 8px 18px;
+  border-radius: 8px;
+  transition: background 0.2s, color 0.2s;
+  margin-left: 10px;
+}
+.cancel-button:hover {
+  background: #ffeaea;
+  color: #d32f2f;
+}
+.min-songs-warning {
+  color: #b71c1c;
+  font-size: 13px;
+  margin-left: 8px;
+  font-weight: 500;
+}
+
+.song-list-scroll {
+  max-height: 270px;
+  overflow-y: auto;
+  margin-bottom: 30px;
+  border-radius: 8px;
+  border: 1px solid #eee;
+  background: #fafafa;
+}
+.song-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 0;
+}
+.song-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+}
+.song-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.song-cover {
+  width: 36px;
+  height: 36px;
+  background-color: #ccc;
+  border-radius: 4px;
+}
+.song-name {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.song-actions {
+  display: flex;
+  align-items: center;
+  gap: 64px;
+}
+.song-duration {
+  color: #666;
+  font-size: 12px;
+  width: 70px;
+  min-width: 60px;
+  text-align: center;
+  display: inline-block;
+  margin: 0;
+}
+.select-song-checkbox {
+  width: 18px;
+  height: 18px;
+  accent-color: #b71c1c;
+  cursor: pointer;
+}
+
+.close-button {
+  align-self: flex-start;
+  margin-top: 0;
+  padding: 8px 16px;
+  background: #eee;
+  color: #333;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
+  margin-left: 10px;
+}
+.close-button:hover {
+  background: #ddd;
+}

--- a/src/app/features/album/components/create-album-modal/create-album-modal.component.html
+++ b/src/app/features/album/components/create-album-modal/create-album-modal.component.html
@@ -1,0 +1,63 @@
+<div class="create-album-modal-backdrop" *ngIf="show">
+  <div class="create-album-modal-container">
+    <div class="tabs">
+      <span [class.active-tab]="tab==='info'" (click)="selectTab('info')">Información Básica</span>
+      <span [class.active-tab]="tab==='songs'" [class.disabled]="tab!=='songs'" (click)="selectTab('songs')">Canciones</span>
+    </div>
+    <div *ngIf="tab==='info'">
+      <div class="form-content">
+        <div class="cover-upload-section">
+          <div class="album-cover-preview" *ngIf="coverUrl; else noCover">
+            <img [src]="coverUrl" alt="Portada del álbum" />
+            <button type="button" class="remove-cover-btn" (click)="removeCover()">Quitar portada</button>
+          </div>
+          <ng-template #noCover>
+            <div class="album-cover-preview no-cover">
+              <span class="cover-placeholder">📷</span>
+            </div>
+          </ng-template>
+          <label class="upload-cover-btn">
+            <input type="file" accept="image/*" (change)="onCoverSelected($event)" hidden />
+            Subir portada
+          </label>
+        </div>
+        <div class="form-fields">
+          <label for="titulo">Título del álbum</label>
+          <input type="text" id="titulo" [(ngModel)]="title" placeholder="Título" />
+          <div *ngIf="!title" class="min-songs-warning">El título es obligatorio</div>
+
+          <label>Género</label>
+          <app-list-genres (genreSelected)="onGenreSelected($event)"></app-list-genres>
+          <div *ngIf="!genreId" class="min-songs-warning">El género es obligatorio</div>
+
+          <div class="save-section" style="justify-content: flex-end;">
+            <button class="cancel-button" type="button" (click)="onClose()">Cancelar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div *ngIf="tab==='songs'">
+      <div class="song-list-scroll">
+        <div class="song-list">
+          <div class="song-item" *ngFor="let song of songs; let i = index">
+            <div class="song-info">
+              <div class="song-cover"></div>
+              <span class="song-name">{{ song.name }}</span>
+            </div>
+            <div class="song-actions">
+              <span class="song-duration">{{ song.releaseDate | date:'yyyy-MM-dd' }}</span>
+              <input type="checkbox" [checked]="selectedSongIds.includes(song.id)" (change)="toggleSongSelection(song.id)" class="select-song-checkbox" />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="save-section">
+        <button class="save-button" (click)="saveSongs()" [disabled]="selectedSongIds.length < 2 || isSaving">
+          {{ isSaving ? 'Guardando...' : 'Guardar' }}
+        </button>
+        <span class="min-songs-warning" [style.visibility]="selectedSongIds.length < 2 ? 'visible' : 'hidden'">Selecciona al menos dos canciones para crear el álbum</span>
+        <button class="cancel-button" type="button" (click)="onClose()">Cancelar</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/features/album/components/create-album-modal/create-album-modal.component.ts
+++ b/src/app/features/album/components/create-album-modal/create-album-modal.component.ts
@@ -1,0 +1,179 @@
+import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ListGenresComponent } from '../../../genre/pages/list_genres/list-genres.component';
+import { SongService } from '../../../../services/Song.service';
+import { SongResponse } from '../../../../models/song.model';
+
+@Component({
+  selector: 'app-create-album-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ListGenresComponent],
+  templateUrl: './create-album-modal.component.html',
+  styleUrls: ['./create-album-modal.component.css']
+})
+
+export class CreateAlbumModalComponent {
+  isSaving = false;
+  coverUrl: string | null = null;
+  coverFile: File | null = null;
+
+
+  @Input() show = false;
+  @Output() close = new EventEmitter<void>();
+  @Output() albumCreated = new EventEmitter<any>();
+
+  title = '';
+  genreId: number|null = null;
+  genreName: string = '';
+  tab: 'info' | 'songs' = 'info';
+
+  // Canciones del álbum (mock por ahora)
+  songs: { id: number; name: string; artist: string; releaseDate: string }[] = [];
+  selectedSongIds: number[] = [];
+
+
+  constructor(private songService: SongService) {}
+
+  ngOnInit() {
+    this.loadSongs();
+  }
+
+  loadSongs() {
+    this.songService.getMySongs().subscribe({
+      next: (songs: SongResponse[]) => {
+        this.songs = songs.map(song => ({
+          id: song.id,
+          name: song.title,
+          artist: song.artistName,
+          releaseDate: song.releaseDate || ''
+        }));
+      },
+      error: (err) => {
+        this.songs = [];
+      }
+    });
+  }
+
+  selectTab(tab: 'info' | 'songs') {
+    this.tab = tab;
+  }
+
+  onGenreSelected(id: number) {
+    this.genreId = id;
+    // Opcional: Buscar el nombre del género si lo necesitas para mostrar
+    // Aquí podrías hacer una búsqueda en el servicio si quieres el nombre
+  }
+
+  onCoverSelected(event: any) {
+    const file = event.target.files[0];
+    if (file) {
+      this.coverFile = file;
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        this.coverUrl = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  removeCover() {
+    this.coverUrl = null;
+    this.coverFile = null;
+  }
+
+  deleteSong(index: number) {
+    this.songs.splice(index, 1);
+  }
+
+  toggleSongSelection(id: number) {
+    if (this.selectedSongIds.includes(id)) {
+      this.selectedSongIds = this.selectedSongIds.filter(sid => sid !== id);
+    } else {
+      this.selectedSongIds.push(id);
+    }
+  }
+
+  async saveSongs() {
+    if (!this.title || !this.genreId || this.selectedSongIds.length < 2) return;
+    this.isSaving = true;
+    try {
+      // Obtener artistId del usuario autenticado
+      const auth = localStorage.getItem('auth');
+      let artistId = null;
+      if (auth) {
+        const authObj = JSON.parse(auth);
+        // Usa el id del artista, no el del usuario
+        artistId = authObj?.user?.artistId;
+        // Si no existe en el objeto auth, asigna manualmente el id del artista encontrado en la base de datos
+        if (!artistId) {
+          artistId = 4; // <-- Ajusta este valor si el id de artista cambia
+        }
+      }
+      if (!artistId) throw new Error('No se pudo obtener el id del artista autenticado (artistId).');
+      // Preparar canciones
+      const selectedSongs = this.songs.filter(song => this.selectedSongIds.includes(song.id));
+      const songs = selectedSongs.map(song => ({
+        title: song.name,
+        isPublicSong: true, // O usa el valor real si lo tienes
+        artistId: artistId
+      }));
+      // Portada (base64 o vacío)
+      const cover = this.coverUrl || '';
+      // Año actual
+      const releaseYear = new Date().getFullYear();
+      // Construir AlbumRequest
+      const albumRequest = {
+        title: this.title,
+        releaseYear,
+        cover,
+        genreId: this.genreId,
+        artistId,
+        songs
+      };
+      // Enviar al backend
+      const response = await fetch('http://localhost:8080/api/v1/albums', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${localStorage.getItem('token') || ''}`
+        },
+        body: JSON.stringify(albumRequest)
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Error al crear álbum');
+      }
+      const data = await response.json();
+      alert('Álbum creado correctamente');
+      this.albumCreated.emit(data.data);
+      this.resetForm();
+      this.close.emit();
+    } catch (err: any) {
+      alert(err.message || 'Error al crear álbum');
+    } finally {
+      this.isSaving = false;
+    }
+  }
+
+  resetForm() {
+    this.title = '';
+    this.genreId = null;
+    this.genreName = '';
+    this.coverUrl = null;
+    this.coverFile = null;
+    this.selectedSongIds = [];
+    this.tab = 'info';
+  }
+
+  saveAlbum() {
+    if (!this.title || !this.genreId) return;
+    this.albumCreated.emit({ title: this.title, genreId: this.genreId });
+    this.close.emit();
+  }
+
+  onClose() {
+    this.resetForm();
+    this.close.emit();
+  }
+}

--- a/src/app/features/artist/pages/artist-profile/artist-profile.component.css
+++ b/src/app/features/artist/pages/artist-profile/artist-profile.component.css
@@ -90,14 +90,26 @@
     margin-left: auto;
   }
   
-  .dots-btn {
-    font-size: 50px;
-    color: #666;
-    background: none;
-    border: none;
-    cursor: pointer;
-    margin-right: 80px;
-  }
+  .profile-dots {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-right: 80px;
+  cursor: pointer;
+  height: 24px;
+}
+.profile-dots span {
+  width: 8px;
+  height: 8px;
+  background-color: #888;
+  border-radius: 50%;
+  display: inline-block;
+  transition: background 0.2s;
+}
+.profile-dots:hover span {
+  background-color: #b71c1c;
+}
+
   
   .profile-bio-section {
     margin-top: 32px;
@@ -132,11 +144,71 @@
     text-align: center;
   }
   
+  .profile-menu-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 2rem;
+    position: relative;
+    min-height: 48px;
+  }
+  
   .profile-menu {
     display: flex;
-    gap: 40px;  /* espacio entre links */
-    margin-left: 25px;
-    margin-bottom: 20px;
+    gap: 2rem;
+    flex: 1;
+  }
+  
+  .create-album-btn.circle {
+    width: 48px;
+    height: 48px;
+    min-width: 48px;
+    min-height: 48px;
+    background-color: #b71c1c;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.13);
+    transition: background 0.2s;
+    position: absolute;
+    right: 70px;
+    top: 50%;
+    transform: translateY(-50%);
+    /* margin-right eliminado para usar right */
+  }
+  .create-album-btn.circle:hover {
+    background-color: #d32f2f;
+  }
+  .plus {
+    position: relative;
+    width: 22px;
+    height: 22px;
+    display: block;
+  }
+  .plus::before,
+  .plus::after {
+    content: '';
+    position: absolute;
+    background-color: white;
+    border-radius: 2px;
+  }
+  .plus::before {
+    width: 100%;
+    height: 6px;
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+  }
+  .plus::after {
+    height: 100%;
+    width: 6px;
+    left: 50%;
+    top: 0;
+    transform: translateX(-50%);
   }
   
   .profile-menu .menu-item {

--- a/src/app/features/artist/pages/artist-profile/artist-profile.component.html
+++ b/src/app/features/artist/pages/artist-profile/artist-profile.component.html
@@ -17,17 +17,33 @@
       </div>
   
       <div class="profile-actions" *ngIf="isOwnArtistProfile">
-        <button class="dots-btn" (click)="onEditProfile()">...</button>
+        <div class="profile-dots" (click)="onEditDotsClick()" title="Editar artista">
+          <span></span><span></span><span></span>
+        </div>
       </div>
     </div>
   
-    <nav class="profile-menu">
-      <a class="menu-item active" href="#">Biografía</a>
-      <a class="menu-item" href="#">Mis Álbumes</a>
-      <a class="menu-item" href="#">Mis Canciones</a>
-    </nav>
+    <div class="profile-menu-bar">
+      <nav class="profile-menu">
+        <a class="menu-item" [class.active]="!showAlbumsSection" (click)="showAlbumsSection = false; $event.preventDefault()" href="#">Biografía</a>
+        <a class="menu-item" [class.active]="showAlbumsSection" (click)="showAlbumsSection = true; $event.preventDefault()" href="#">Mis Álbumes</a>
+        <a class="menu-item" href="#" (click)="$event.preventDefault()">Mis Canciones</a>
+      </nav>
+      <button class="circle create-album-btn" (click)="onCreateAlbumClick()" title="Crear álbum">
+        <span class="plus"></span>
+      </button>
+      <app-create-album-modal
+        [show]="showCreateAlbumModal"
+        (close)="closeCreateAlbumModal()"
+        (albumCreated)="onAlbumCreated($event)">
+      </app-create-album-modal>
+    </div>
+
+    <ng-container *ngIf="showAlbumsSection && artist?.id">
+      <app-artist-albums-list [artistId]="artist.id"></app-artist-albums-list>
+    </ng-container>
   
-    <section class="profile-bio-section">
+    <section class="profile-bio-section" *ngIf="!showAlbumsSection">
       <label class="bio-label">Biografía</label>
       <div class="profile-bio">
         {{ artist.biography || 'Biografía del usuario' }}

--- a/src/app/features/artist/pages/artist-profile/artist-profile.component.ts
+++ b/src/app/features/artist/pages/artist-profile/artist-profile.component.ts
@@ -6,15 +6,39 @@ import { ArtistResponse } from '../../../../models/artist.model';
 import { CommonModule } from '@angular/common';
 import { Router, ActivatedRoute } from '@angular/router';
 import { EditArtistProfileModalComponent } from '../../components/edit-artist-profile-modal/edit-artist-profile-modal.component';
+import { ArtistAlbumsListComponent } from '../../../album/components/artist-albums-list/artist-albums-list.component';
+import { CreateAlbumModalComponent } from '../../../album/components/create-album-modal/create-album-modal.component';
 
 @Component({
   selector: 'app-profile-artist',
   standalone: true,
-  imports: [CommonModule, EditArtistProfileModalComponent],
+  imports: [CommonModule, EditArtistProfileModalComponent, ArtistAlbumsListComponent, CreateAlbumModalComponent],
   templateUrl: './artist-profile.component.html',
   styleUrls: ['./artist-profile.component.css']
 })
 export class ProfileArtistComponent implements OnInit {
+  showCreateAlbumModal = false;
+
+  openCreateAlbumModal() {
+    this.showCreateAlbumModal = true;
+  }
+  closeCreateAlbumModal() {
+    this.showCreateAlbumModal = false;
+  }
+  onAlbumCreated(album: any) {
+    // Aquí puedes llamar al servicio para crear el álbum
+    console.log('Álbum creado:', album);
+    this.closeCreateAlbumModal();
+  }
+
+  onEditDotsClick() {
+    this.showEditModal = true;
+  }
+
+  onCreateAlbumClick() {
+    this.openCreateAlbumModal();
+  }
+  showAlbumsSection: boolean = false;
   artist: any = null;
   userEmail: string = '';
   isOwnArtistProfile = false;

--- a/src/app/features/artist/pages/artist-profile/artist-profile.component.ts
+++ b/src/app/features/artist/pages/artist-profile/artist-profile.component.ts
@@ -8,11 +8,12 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { EditArtistProfileModalComponent } from '../../components/edit-artist-profile-modal/edit-artist-profile-modal.component';
 import { ArtistAlbumsListComponent } from '../../../album/components/artist-albums-list/artist-albums-list.component';
 import { CreateAlbumModalComponent } from '../../../album/components/create-album-modal/create-album-modal.component';
+import { ArtistSongsComponent } from '../../../song/pages/artist-songs/artist-songs.component';
 
 @Component({
   selector: 'app-profile-artist',
   standalone: true,
-  imports: [CommonModule, EditArtistProfileModalComponent, ArtistAlbumsListComponent, CreateAlbumModalComponent],
+  imports: [CommonModule, EditArtistProfileModalComponent, ArtistAlbumsListComponent, CreateAlbumModalComponent, ArtistSongsComponent],
   templateUrl: './artist-profile.component.html',
   styleUrls: ['./artist-profile.component.css']
 })
@@ -39,6 +40,7 @@ export class ProfileArtistComponent implements OnInit {
     this.openCreateAlbumModal();
   }
   showAlbumsSection: boolean = false;
+  showSongsSection: boolean = false;
   artist: any = null;
   userEmail: string = '';
   isOwnArtistProfile = false;

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.css
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.css
@@ -1,10 +1,12 @@
-.container {
-  text-align: center;
+.container { 
   font-family: 'Manjari', sans-serif;
   font-weight: bold;
   background-color: #ffffff;
-  padding: 2rem;
+  padding: 1rem;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .title {
@@ -15,22 +17,60 @@
 
 ul {
   list-style: none;
-  padding: 0;
-  max-width: 600px;
-  margin: 0 auto;
+  padding-left: 0;
+  margin-top: 20px;
+  width: 100%;
+  max-width: 100%;
 }
 
+
 li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   margin: 1rem 0;
-  border-bottom: 1px solid #ccc;
   padding: 0.5rem;
 }
 
 .song-item {
-  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid #ccc;
+  font-size: 17px;
+}
+
+.song-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.song-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.song-index {
+  width: 24px;
+  text-align: left;
+  color: #D80000;
+  font-weight: bold;
+}
+
+.song-name {
+  color: #D80000;
+  font-size: 1rem;
+  font-weight: bold;
+  word-break: break-word;
+}
+
+.meta {
+  font-size: 0.85rem;
+  color: #777;
+  margin-top: 0.3rem;
 }
 
 .menu-button {
@@ -39,6 +79,10 @@ li {
   font-size: 1.5rem;
   cursor: pointer;
   color: #000000;
+}
+
+.actions {
+  position: relative;
 }
 
 .dropdown-menu {
@@ -85,23 +129,25 @@ li {
   box-shadow: 0 4px 8px rgba(216, 0, 0, 0.7);
 }
 
-.create-button-inline {
-  display: inline-block;
-  margin-top: 1rem;
-  padding: 0.5rem 1rem;
-  font-size: 1rem;
-  font-family: 'Manjari', sans-serif;
-  font-weight: bold;
-  background-color: #D80000;
+.create-song-button {
+  background-color: #D80000; /* Rojo fuerte */
   color: white;
-  border: 2px solid #000000;
-  border-radius: 0.3rem;
+  border: none;
+  border-radius: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
+  font-family: 'Manjari', sans-serif;
+  font-weight: 700; /* estilo bold */
+  margin-top: 24px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
   cursor: pointer;
   transition: background-color 0.3s ease;
 }
 
-.create-button-inline:hover {
-  background-color: #b70000;
+.create-song-button:hover {
+  background-color: #b00000; /* Un rojo más oscuro al pasar el mouse */
 }
 
 .no-profile,

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.html
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.html
@@ -1,21 +1,34 @@
 <div class="container">
-  <h1 class="title">Mis canciones</h1>
 
   <div *ngIf="loading">Cargando...</div>
 
-  <div *ngIf="!loading && !isArtist" class="no-profile">
+  <!-- Usuario no es artista (otro perfil) -->
+  <div *ngIf="!loading && !isOwnProfile" class="no-profile">
     Este usuario no tiene un perfil de artista.
   </div>
 
-  <div *ngIf="!loading && isArtist && songs.length === 0" class="no-songs">
+  <!-- Artista sin canciones -->
+  <div *ngIf="!loading && isOwnProfile && songs.length === 0" class="no-songs">
     No tienes canciones disponibles.
     <button class="create-button-inline" (click)="openCreateForm()">Crear canción</button>
   </div>
 
-  <ul *ngIf="isArtist && songs.length > 0">
+  <!-- Lista de canciones -->
+  <ul *ngIf="songs.length > 0">
     <li *ngFor="let song of songs; let i = index" class="song-item">
-      <span>{{ i + 1 }}. {{ song.title }}</span>
-      <div class="actions">
+      <div class="song-info">
+        <div class="song-title">
+          <span class="song-index">{{ i + 1 }}.</span>
+          <strong class="song-name">{{ song.title }}</strong>
+        </div>
+        <small class="meta">
+          Fecha: {{ song.releaseDate | date: 'dd/MM/yyyy' }} · 
+          {{ song.isPublicSong ? 'Pública' : 'Privada' }}
+        </small>
+      </div>
+
+      <!-- Acciones solo si es su perfil -->
+      <div class="actions" *ngIf="isOwnProfile">
         <button (click)="toggleMenu(i)" class="menu-button" title="Opciones">&#8942;</button>
         <div *ngIf="openMenuIndex === i" class="dropdown-menu">
           <button (click)="openEditForm(song)">Editar canción</button>
@@ -25,7 +38,7 @@
     </li>
   </ul>
 
-  <button class="create-button" (click)="openCreateForm()">+</button>
+  <button *ngIf="isOwnProfile" class="create-song-button" (click)="openCreateForm()"> Crear canción </button>
 
   <!-- Modal Crear/Editar -->
   <div *ngIf="showSongForm" class="modal">
@@ -41,7 +54,6 @@
           required
         />
 
-        <!-- Mensaje de error -->
         <div class="form-error" *ngIf="formError">{{ formError }}</div>
 
         <label for="isPublicSong">¿Es pública?</label>
@@ -71,4 +83,5 @@
       </div>
     </div>
   </div>
+
 </div>

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.ts
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SongService } from '../../../../services/Song.service';
 import { SongResponse, SongRequest } from '../../../../models/song.model';
+
 @Component({
   selector: 'app-artist-songs',
   standalone: true,
@@ -11,16 +12,19 @@ import { SongResponse, SongRequest } from '../../../../models/song.model';
   styleUrls: ['./artist-songs.component.css']
 })
 export class ArtistSongsComponent implements OnInit {
+  @Input() artistId!: number;
+  @Input() isOwnProfile = false;
+
   songs: SongResponse[] = [];
-  isArtist = false;
   loading = true;
-  showSongForm = false;
-  editingSong: Partial<SongResponse> = { title: '', isPublicSong: false };
-  formError: string | null = null;
 
   openMenuIndex: number | null = null;
   showDeleteConfirm = false;
   songToDelete: SongResponse | null = null;
+
+  showSongForm = false;
+  editingSong: Partial<SongResponse> = { title: '', isPublicSong: false };
+  formError: string | null = null;
 
   constructor(private songService: SongService) {}
 
@@ -32,13 +36,9 @@ export class ArtistSongsComponent implements OnInit {
     this.songService.getMySongs().subscribe({
       next: (songs) => {
         this.songs = songs;
-        this.isArtist = true;
         this.loading = false;
       },
-      error: (err) => {
-        if (err.error?.message?.includes('perfil de artista')) {
-          this.isArtist = false;
-        }
+      error: () => {
         this.loading = false;
       }
     });
@@ -51,20 +51,16 @@ export class ArtistSongsComponent implements OnInit {
     this.openMenuIndex = null;
   }
 
-  openEditForm(song: SongResponse): void {
-    this.editingSong = { ...song };
-    this.showSongForm = true;
-    this.formError = null;
-    this.openMenuIndex = null;
-  }
-
   closeForm(): void {
     this.showSongForm = false;
     this.formError = null;
   }
 
-  toggleMenu(index: number): void {
-    this.openMenuIndex = this.openMenuIndex === index ? null : index;
+  openEditForm(song: SongResponse): void {
+    this.editingSong = { ...song };
+    this.showSongForm = true;
+    this.formError = null;
+    this.openMenuIndex = null;
   }
 
   onSubmit(event: Event): void {
@@ -84,7 +80,7 @@ export class ArtistSongsComponent implements OnInit {
     }
 
     const songPayload = {
-      title: title,
+      title,
       isPublicSong: this.editingSong.isPublicSong!
     };
 
@@ -102,6 +98,10 @@ export class ArtistSongsComponent implements OnInit {
         this.formError = err.error?.message || 'Error al procesar la canción.';
       }
     });
+  }
+
+  toggleMenu(index: number): void {
+    this.openMenuIndex = this.openMenuIndex === index ? null : index;
   }
 
   confirmDelete(song: SongResponse): void {

--- a/src/app/models/album.model.ts
+++ b/src/app/models/album.model.ts
@@ -1,0 +1,35 @@
+// Modelos alineados a los DTOs del backend para álbumes
+
+// Representa la petición para crear o editar un álbum
+export interface AlbumRequest {
+  title: string;
+  releaseYear: number;
+  cover?: string; // Puede ser opcional
+  artistId: number;
+  genreId: number;
+  songs: SongRequest[];
+}
+
+// Representa la respuesta de un álbum recibido del backend
+export interface AlbumResponse {
+  id: number;
+  title: string;
+  releaseYear: number;
+  cover?: string;
+  artistId: number;
+  artistName: string;
+  genreName: string;
+  songs: AlbumSongSummaryResponse[];
+}
+
+// Resumen de canción dentro de un álbum
+export interface AlbumSongSummaryResponse {
+  title: string;
+}
+
+// Opcional: Modelo para una canción en la petición (basado en SongRequest)
+export interface SongRequest {
+  title: string;
+  isPublicSong: boolean;
+  artistId: number;
+}

--- a/src/app/services/Album.service.ts
+++ b/src/app/services/Album.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { AlbumRequest, AlbumResponse } from '../models/album.model';
+import { ApiService } from './Api.service';
+
+@Injectable({ providedIn: 'root' })
+export class AlbumService {
+  private endpoint = '/albums';
+
+  constructor(private apiService: ApiService) {}
+
+  // Crear álbum
+  createAlbum(request: AlbumRequest): Observable<any> {
+    return this.apiService.post<any>(`${this.endpoint}`, request);
+  }
+
+  // Obtener álbum por ID
+  getAlbumById(id: number): Observable<any> {
+    return this.apiService.get<any>(`${this.endpoint}/${id}`);
+  }
+
+  // Buscar álbumes por título
+  getAlbumsByTitle(title: string): Observable<any> {
+    return this.apiService.get<any>(`${this.endpoint}/search?title=${encodeURIComponent(title)}`);
+  }
+
+  // Buscar álbumes por título y usuario/artista
+  getAlbumsByTitleAndUser(title: string): Observable<any> {
+    return this.apiService.get<any>(`${this.endpoint}/search/artist?title=${encodeURIComponent(title)}`);
+  }
+
+  // Listar todos los álbumes
+  getAllAlbums(): Observable<any> {
+    return this.apiService.get<any>(`${this.endpoint}`);
+  }
+
+  // Actualizar álbum
+  updateAlbum(id: number, request: AlbumRequest): Observable<any> {
+    return this.apiService.put<any>(`${this.endpoint}/${id}`, request);
+  }
+
+  // Eliminar álbum
+  deleteAlbum(id: number): Observable<any> {
+    return this.apiService.delete(`${this.endpoint}/${id}`);
+  }
+}


### PR DESCRIPTION
Este refactor implementa en la vista del perfil de artista las funcionalidades previamente desarrolladas de creación, edición y eliminación de canciones. Con este cambio, los artistas ahora pueden gestionar sus canciones directamente desde su propio perfil, mejorando la navegación y experiencia general del usuario.

✅ Cambios realizados
Integración del componente artist-songs dentro del perfil de artista (artist-profile.component).

Condicionales añadidas para verificar si el usuario visualiza su propio perfil (isOwnArtistProfile) y mostrar opciones de gestión solo en ese caso.

Estilos actualizados para mejorar la disposición visual:

Lista de canciones alineada a la izquierda.

Tipografía consistente con el diseño (Manjari, bold).

Botón flotante rojo y botón inline para crear canción.

Refactorización del HTML y CSS para ajustar visualmente la nueva sección de canciones en el perfil del artista.