### PR TITLE
feat: componente para agregar canciones a playlists desde popup [US-05]

### DIFF
--- a/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.css
+++ b/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.css
@@ -1,19 +1,98 @@
 .modal-backdrop {
-  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 1000;
+  position: fixed; 
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(20,20,20,0.5);
+  display: flex; 
+  align-items: center; 
+  justify-content: center;
+  z-index: 1200;
 }
+
 .modal-content {
-  background: #fff; padding: 24px; border-radius: 14px; min-width: 300px;
+  background: #fff;
+  color: #141414;
+  padding: 32px 24px 22px 24px;
+  border-radius: 16px;
+  box-shadow: 0 8px 36px rgba(0,0,0,0.18);
+  min-width: 320px;
+  max-width: 90vw;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
+
 .close-btn {
-  position: absolute; right: 12px; top: 12px;
-  background: none; border: none; font-size: 22px; cursor: pointer;
+  position: absolute;
+  right: 14px;
+  top: 14px;
+  background: none;
+  border: none;
+  font-size: 28px;
+  color: #d80000;
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.18s;
 }
+.close-btn:hover { opacity: 1; }
+
+h2 {
+  font-family: 'Manjari', Arial, sans-serif;
+  color: #b71c1c;
+  font-size: 22px;
+  font-weight: bold;
+  margin-bottom: 18px;
+}
+
 .playlist-option {
-  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 12px;
 }
+
+input[type="checkbox"] {
+  accent-color: #b71c1c; /* Checkbox en rojo */
+  width: 18px; height: 18px;
+  border-radius: 6px;
+  border: 2px solid #b71c1c;
+  cursor: pointer;
+  transition: box-shadow 0.15s;
+}
+input[type="checkbox"]:hover {
+  box-shadow: 0 0 0 2px #ffeaea;
+}
+
+.playlist-label {
+  font-family: 'Manjari', Arial, sans-serif;
+  font-size: 16px;
+  color: #141414;
+}
+
+.add-btn {
+  width: 50%;
+  display: block;
+  padding: 12px;
+  background: #d80000;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  font-family: 'Manjari', Arial, sans-serif;
+  font-size: 18px;
+  font-weight: bold;
+  margin: 18px auto 0 auto;
+  cursor: pointer;
+  transition: background 0.18s;
+  box-shadow: 0 2px 8px rgba(185,0,0,0.09);
+}
+
+.add-btn:hover {
+  background: #b71c1c;
+}
+
 .error {
   color: #b71c1c;
+  margin-top: 10px;
+  font-size: 15px;
+  font-family: 'Manjari', Arial, sans-serif;
 }

--- a/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.css
+++ b/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.css
@@ -1,0 +1,19 @@
+.modal-backdrop {
+  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000;
+}
+.modal-content {
+  background: #fff; padding: 24px; border-radius: 14px; min-width: 300px;
+}
+.close-btn {
+  position: absolute; right: 12px; top: 12px;
+  background: none; border: none; font-size: 22px; cursor: pointer;
+}
+.playlist-option {
+  margin-bottom: 10px;
+}
+.error {
+  color: #b71c1c;
+}

--- a/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.html
+++ b/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.html
@@ -1,20 +1,20 @@
 <div class="modal-backdrop">
   <div class="modal-content">
     <button class="close-btn" (click)="close.emit()">×</button>
-    <h2>Agregar canción a tus playlists</h2>
+    <h2>Agregar a Playlist</h2>
     <div *ngIf="loading">Cargando...</div>
     <div *ngIf="error" class="error">{{ error }}</div>
     <form *ngIf="!loading && playlists.length > 0">
       <div *ngFor="let playlist of playlists" class="playlist-option">
-        <label>
+        <label class="playlist-label">
           <input type="checkbox"
                  [checked]="selectedPlaylistIds.has(playlist.playlistId)"
                  (change)="togglePlaylist(playlist.playlistId)">
           {{ playlist.name }}
         </label>
       </div>
-      <button type="button" (click)="confirmAdd()" [disabled]="selectedPlaylistIds.size === 0 || loading">
-        Añadir a seleccionadas
+      <button class="add-btn" (click)="confirmAdd()" [disabled]="selectedPlaylistIds.size === 0 || loading">
+        Añadir 
       </button>
     </form>
     <div *ngIf="!loading && playlists.length === 0">No tienes playlists aún.</div>

--- a/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.html
+++ b/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.html
@@ -1,0 +1,22 @@
+<div class="modal-backdrop">
+  <div class="modal-content">
+    <button class="close-btn" (click)="close.emit()">×</button>
+    <h2>Agregar canción a tus playlists</h2>
+    <div *ngIf="loading">Cargando...</div>
+    <div *ngIf="error" class="error">{{ error }}</div>
+    <form *ngIf="!loading && playlists.length > 0">
+      <div *ngFor="let playlist of playlists" class="playlist-option">
+        <label>
+          <input type="checkbox"
+                 [checked]="selectedPlaylistIds.has(playlist.playlistId)"
+                 (change)="togglePlaylist(playlist.playlistId)">
+          {{ playlist.name }}
+        </label>
+      </div>
+      <button type="button" (click)="confirmAdd()" [disabled]="selectedPlaylistIds.size === 0 || loading">
+        Añadir a seleccionadas
+      </button>
+    </form>
+    <div *ngIf="!loading && playlists.length === 0">No tienes playlists aún.</div>
+  </div>
+</div>

--- a/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.ts
+++ b/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.ts
@@ -1,0 +1,62 @@
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { PlaylistService } from '../../../../services/playlist.service'; 
+import { PlaylistResponse } from '../../../../models/playlist.model';
+import { NgIf,NgFor } from '@angular/common';
+@Component({
+  selector: 'app-add-song-to-playlist-modal',
+  templateUrl: './add-song-to-playlist.component.html',
+  styleUrls: ['./add-song-to-playlist.component.css'],
+  imports: [NgIf, NgFor]
+})
+export class AddSongToPlaylistModalComponent implements OnInit {
+  @Input() songId!: number;
+  @Output() close = new EventEmitter<void>();
+  @Output() songAdded = new EventEmitter<void>();
+  
+  playlists: PlaylistResponse[] = [];
+  selectedPlaylistIds: Set<number> = new Set();
+  loading = false;
+  error = '';
+
+  constructor(private playlistService: PlaylistService) {}
+
+  ngOnInit() {
+    this.loading = true;
+    this.playlistService.getMyPlaylists().subscribe({
+      next: (playlists) => {
+        this.playlists = playlists;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Error al cargar playlists';
+        this.loading = false;
+      }
+    });
+  }
+
+  togglePlaylist(playlistId: number) {
+    if (this.selectedPlaylistIds.has(playlistId)) {
+      this.selectedPlaylistIds.delete(playlistId);
+    } else {
+      this.selectedPlaylistIds.add(playlistId);
+    }
+  }
+
+  confirmAdd() {
+    this.loading = true;
+    const requests = Array.from(this.selectedPlaylistIds).map(pid =>
+      this.playlistService.addSongToPlaylist(pid, this.songId)
+    );
+    // Lanza todos los requests (podrías usar forkJoin si quieres esperar a todos)
+    Promise.all(requests.map(req => req.toPromise()))
+      .then(() => {
+        this.loading = false;
+        this.songAdded.emit();
+        this.close.emit();
+      })
+      .catch(() => {
+        this.error = 'Error al agregar la canción a las playlists';
+        this.loading = false;
+      });
+  }
+}

--- a/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.ts
+++ b/src/app/features/playlist/components/agregar-cancion-playlist/add-song-to-playlist.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { PlaylistService } from '../../../../services/playlist.service'; 
 import { PlaylistResponse } from '../../../../models/playlist.model';
 import { NgIf,NgFor } from '@angular/common';
+
 @Component({
   selector: 'app-add-song-to-playlist-modal',
   templateUrl: './add-song-to-playlist.component.html',
@@ -47,7 +48,7 @@ export class AddSongToPlaylistModalComponent implements OnInit {
     const requests = Array.from(this.selectedPlaylistIds).map(pid =>
       this.playlistService.addSongToPlaylist(pid, this.songId)
     );
-    // Lanza todos los requests (podrías usar forkJoin si quieres esperar a todos)
+    
     Promise.all(requests.map(req => req.toPromise()))
       .then(() => {
         this.loading = false;

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.html
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.html
@@ -33,6 +33,7 @@
         <div *ngIf="openMenuIndex === i" class="dropdown-menu">
           <button (click)="openEditForm(song)">Editar canción</button>
           <button (click)="confirmDelete(song)">Eliminar canción</button>
+          <button (click)="openAddToPlaylist(song)">Agregar a Playlist</button>
         </div>
       </div>
     </li>
@@ -83,5 +84,13 @@
       </div>
     </div>
   </div>
+
+<app-add-song-to-playlist-modal
+  *ngIf="showAddToPlaylistModal && selectedSongForPlaylist"
+  [songId]="selectedSongForPlaylist.id"
+  (close)="onCloseAddToPlaylist()"
+  (songAdded)="onSongAddedToPlaylist()">
+</app-add-song-to-playlist-modal>
+
 
 </div>

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.ts
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.ts
@@ -3,11 +3,12 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SongService } from '../../../../services/Song.service';
 import { SongResponse, SongRequest } from '../../../../models/song.model';
+import { AddSongToPlaylistModalComponent } from '../../../playlist/components/agregar-cancion-playlist/add-song-to-playlist.component';
 
 @Component({
   selector: 'app-artist-songs',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, AddSongToPlaylistModalComponent],
   templateUrl: './artist-songs.component.html',
   styleUrls: ['./artist-songs.component.css']
 })
@@ -25,6 +26,9 @@ export class ArtistSongsComponent implements OnInit {
   showSongForm = false;
   editingSong: Partial<SongResponse> = { title: '', isPublicSong: false };
   formError: string | null = null;
+
+  selectedSongForPlaylist: SongResponse | null = null;
+  showAddToPlaylistModal = false;
 
   constructor(private songService: SongService) {}
 
@@ -127,5 +131,20 @@ export class ArtistSongsComponent implements OnInit {
         alert('Error al eliminar la canción.');
       }
     });
+  }
+
+  openAddToPlaylist(song: SongResponse) {
+  this.selectedSongForPlaylist = song;
+  this.showAddToPlaylistModal = true;
+  }
+
+  onCloseAddToPlaylist() {
+    this.showAddToPlaylistModal = false;
+    this.selectedSongForPlaylist = null;
+  }
+
+  onSongAddedToPlaylist() {
+    this.showAddToPlaylistModal = false;
+    this.selectedSongForPlaylist = null;
   }
 }


### PR DESCRIPTION
Resumen:
Se implementa un componente modal (popup) que permite seleccionar a qué playlists del usuario añadir una canción.

El popup muestra todas las playlists personales usando checkboxes estilizados en rojo según la identidad visual del proyecto.

Se añadió botón de confirmación "Añadir a seleccionadas" con estilos consistentes con los botones principales del sistema.

Mejora de UI/UX:

Botón de cerrar popup tipo X en la esquina superior derecha.

Los checkboxes y labels mantienen el branding y consistencia de componentes previos.

El código sigue clean code: separación lógica de UI y manejo de estado.

Preparado para futuras extensiones (e.g., búsqueda de playlists, mensajes de éxito, etc).

Archivos principales modificados/agregados:
Nuevo componente popup: (HTML, CSS y TS)

Integración con método getMyPlaylists del service de frontend.

Consideraciones:
Falta implementar feedback visual al añadir exitosamente (puede ser agregado en el siguiente sprint).

