### PR TITLE
Fix/album implementation

### DIFF
--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.css
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.css
@@ -124,3 +124,20 @@
   border-bottom: 6px solid transparent;
   margin-left: 2px;
 }
+
+.no-albums {
+  color: #D80000;
+  font-weight: bold;
+  margin-top: 2rem;
+}
+
+.albums-list-container {
+  font-family: 'Manjari', sans-serif;
+  font-weight: bold;
+  background-color: #ffffff;
+  padding: 1rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.html
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.html
@@ -13,15 +13,17 @@
         <div class="album-info">
           <p class="album-name">{{ album.title }}</p>
           <p class="album-owner">{{ album.artistName }}</p>
-<div class="dots" (click)="toggleAlbumMenu(album)">
-  <span></span>
-  <span></span>
-  <span></span>
-</div>
-<div *ngIf="openMenuAlbumId === album.id" class="dropdown-menu">
-  <button (click)="editAlbum(album)">Editar Álbum</button>
-  <button (click)="confirmDeleteAlbum(album)">Eliminar Álbum</button>
-</div>
+<ng-container *ngIf="isOwnProfile">
+  <div class="dots" (click)="toggleAlbumMenu(album)">
+    <span></span>
+    <span></span>
+    <span></span>
+  </div>
+  <div *ngIf="openMenuAlbumId === album.id" class="dropdown-menu">
+    <button (click)="editAlbum(album)">Editar Álbum</button>
+    <button (click)="confirmDeleteAlbum(album)">Eliminar Álbum</button>
+  </div>
+</ng-container>
         </div>
         <button class="play-button" [routerLink]="['/album', album.id]" title="Ver álbum"></button>
       </div>
@@ -29,17 +31,19 @@
   </ng-container>
 </div>
 
-<app-edit-album-modal
-  [show]="showEditModal"
-  [album]="albumToEdit"
-  (close)="closeEditModal()"
-  (albumEdited)="fetchAlbums()"
-></app-edit-album-modal>
+<ng-container *ngIf="isOwnProfile">
+  <app-edit-album-modal
+    [show]="showEditModal"
+    [album]="albumToEdit"
+    (close)="closeEditModal()"
+    (albumEdited)="fetchAlbums()"
+  ></app-edit-album-modal>
 
-<app-delete-album-modal
-  [show]="showDeleteModal"
-  [albumTitle]="albumToDelete?.title || ''"
-  [albumId]="albumToDelete?.id"
-  (close)="closeDeleteModal()"
-  (albumDeleted)="onAlbumDeleted()"
-></app-delete-album-modal>
+  <app-delete-album-modal
+    [show]="showDeleteModal"
+    [albumTitle]="albumToDelete?.title || ''"
+    [albumId]="albumToDelete?.id"
+    (close)="closeDeleteModal()"
+    (albumDeleted)="onAlbumDeleted()"
+  ></app-delete-album-modal>
+</ng-container>

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.html
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.html
@@ -2,13 +2,11 @@
   <ng-container *ngIf="isLoading">
     <p>Cargando álbumes...</p>
   </ng-container>
-  <ng-container *ngIf="error">
-    <p>{{ error }}</p>
+
+  <ng-container *ngIf="!isLoading && albums.length === 0">
+    <p class="no-albums">No tienes álbumes disponibles.</p>
   </ng-container>
-  <ng-container *ngIf="!isLoading && !error && albums.length === 0">
-    <p>No hay álbumes para mostrar.</p>
-  </ng-container>
-  <ng-container *ngIf="!isLoading && !error && albums.length > 0">
+  <ng-container *ngIf="!isLoading && albums.length > 0">
     <div class="albums-list">
       <div class="album-card" *ngFor="let album of albums">
         <div class="album-image" [ngStyle]="{ 'background-image': album.cover ? 'url(' + album.cover + ')' : '' }"></div>

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
@@ -16,6 +16,7 @@ import { DeleteAlbumModalComponent } from '../delete-album-modal/delete-album-mo
 })
 
 export class ArtistAlbumsListComponent implements OnInit, OnDestroy {
+  @Input() isOwnProfile: boolean = false;
 
   openMenuAlbumId: number | null = null;
   showEditModal: boolean = false;

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
@@ -107,7 +107,7 @@ export class ArtistAlbumsListComponent implements OnInit, OnDestroy {
         this.isLoading = false;
       },
       error: (err) => {
-        this.error = 'No tienes álbumes disponibles';
+        this.albums = [];
         this.isLoading = false;
       }
     });

--- a/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
+++ b/src/app/features/album/components/artist-albums-list/artist-albums-list.component.ts
@@ -107,7 +107,7 @@ export class ArtistAlbumsListComponent implements OnInit, OnDestroy {
         this.isLoading = false;
       },
       error: (err) => {
-        this.error = 'Error al cargar los álbumes';
+        this.error = 'No tienes álbumes disponibles';
         this.isLoading = false;
       }
     });

--- a/src/app/features/album/components/create-album-modal/create-album-modal.component.ts
+++ b/src/app/features/album/components/create-album-modal/create-album-modal.component.ts
@@ -124,37 +124,31 @@ export class CreateAlbumModalComponent implements OnInit, OnChanges {
     try {
       // Obtener artistId del usuario autenticado
       const auth = localStorage.getItem('auth');
-      let artistId = null;
+      let artistId: number | undefined = undefined;
       if (auth) {
         const authObj = JSON.parse(auth);
-        // Usa el id del artista, no el del usuario
         artistId = authObj?.user?.artistId;
-        // Si no existe en el objeto auth, asigna manualmente el id del artista encontrado en la base de datos
-        if (!artistId) {
-          artistId = 4; // <-- Ajusta este valor si el id de artista cambia
-        }
       }
-      if (!artistId) throw new Error('No se pudo obtener el id del artista autenticado (artistId).');
-      // Preparar canciones
+      // Preparar canciones (solo { title })
       const selectedSongs = this.songs.filter(song => this.selectedSongIds.includes(song.id));
       const songs = selectedSongs.map(song => ({
-        title: song.name,
-        isPublicSong: true, // O usa el valor real si lo tienes
-        artistId: artistId
+        title: song.name
       }));
       // Portada (base64 o vacío)
       const cover = this.coverUrl || '';
       // Año actual
       const releaseYear = new Date().getFullYear();
       // Construir AlbumRequest
-      const albumRequest = {
+      const albumRequest: any = {
         title: this.title,
         releaseYear,
         cover,
         genreId: this.genreId,
-        artistId,
         songs
       };
+      if (artistId) {
+        albumRequest.artistId = artistId;
+      }
       // Enviar al backend
       const response = await fetch('http://localhost:8080/api/v1/albums', {
         method: 'POST',

--- a/src/app/features/album/components/create-album-modal/create-album-modal.component.ts
+++ b/src/app/features/album/components/create-album-modal/create-album-modal.component.ts
@@ -159,6 +159,10 @@ export class CreateAlbumModalComponent implements OnInit, OnChanges {
         body: JSON.stringify(albumRequest)
       });
       if (!response.ok) {
+        if (response.status === 409) {
+          // Error por título duplicado
+          throw new Error('El título del álbum ya existe para este artista.');
+        }
         const errorData = await response.json();
         throw new Error(errorData.message || 'Error al crear álbum');
       }

--- a/src/app/features/album/components/edit-album-modal/edit-album-modal.component.ts
+++ b/src/app/features/album/components/edit-album-modal/edit-album-modal.component.ts
@@ -114,9 +114,15 @@ export class EditAlbumModalComponent implements OnChanges {
         this.albumEdited.emit();
         this.close.emit();
       },
-      error: () => {
+      error: (err: any) => {
         this.isSaving = false;
-        // Manejo de error opcional
+        let msg = 'Error al editar álbum';
+        if (err && err.status === 409) {
+          msg = 'El título del álbum ya existe para este artista.';
+        } else if (err && err.error && err.error.message) {
+          msg = err.error.message;
+        }
+        alert(msg);
       }
     });
   }

--- a/src/app/features/album/pages/album-detail-page/album-detail-page.component.css
+++ b/src/app/features/album/pages/album-detail-page/album-detail-page.component.css
@@ -12,6 +12,33 @@ body {
 .album-detail-root {
     min-height: 100vh;
     background: linear-gradient(to bottom, #2b0000, #550000);
+    position: relative;
+}
+
+.close-btn {
+    position: absolute;
+    top: 24px;
+    right: 24px;
+    z-index: 10;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background: #444;
+    color: #fff;
+    font-size: 1.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+    transition: background 0.2s, color 0.2s;
+    opacity: 0.92;
+}
+.close-btn:hover {
+    background: #222;
+    color: #ff5252;
+    opacity: 1;
 }
 
 .header {

--- a/src/app/features/album/pages/album-detail-page/album-detail-page.component.html
+++ b/src/app/features/album/pages/album-detail-page/album-detail-page.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="loading" class="album-loading">Cargando álbum...</div>
 <div *ngIf="error" class="album-error">{{ error }}</div>
 <div *ngIf="album && !loading" class="album-detail-root">
+  <button class="close-btn" (click)="goToArtistProfile()" title="Cerrar">&#10005;</button>
   <div class="header" [ngStyle]="{'background-image': 'url(' + album.cover + ')'}">
     <h1>{{ album.title }}</h1>
     <div class="details">

--- a/src/app/features/album/pages/album-detail-page/album-detail-page.component.ts
+++ b/src/app/features/album/pages/album-detail-page/album-detail-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AlbumService } from '../../../../services/Album.service';
 
 @Component({
@@ -15,7 +15,7 @@ export class AlbumDetailPageComponent implements OnInit {
   loading = true;
   error = '';
 
-  constructor(private route: ActivatedRoute, private albumService: AlbumService) {}
+  constructor(private route: ActivatedRoute, private albumService: AlbumService, private router: Router) {}
 
   ngOnInit() {
     const albumId = this.route.snapshot.paramMap.get('id');
@@ -36,5 +36,9 @@ export class AlbumDetailPageComponent implements OnInit {
         this.loading = false;
       }
     });
+  }
+
+  public goToArtistProfile() {
+    this.router.navigate(['/artist/profile-artist']);
   }
 }

--- a/src/app/features/artist/pages/artist-profile/artist-profile.component.html
+++ b/src/app/features/artist/pages/artist-profile/artist-profile.component.html
@@ -39,7 +39,7 @@
         <a class="menu-item" [class.active]="showSongsSection" (click)="showSongsSection = true; showAlbumsSection = false; $event.preventDefault()" href="#">Mis Canciones</a>
       </nav>
 
-       <button *ngIf="showAlbumsSection"
+       <button *ngIf="showAlbumsSection && isOwnArtistProfile"
             class="circle create-album-btn"
             (click)="onCreateAlbumClick()"
             title="Crear álbum">
@@ -54,7 +54,7 @@
     </div>
 
     <ng-container *ngIf="showAlbumsSection && artist?.id">
-      <app-artist-albums-list [artistId]="artist.id"></app-artist-albums-list>
+      <app-artist-albums-list [artistId]="artist.id" [isOwnProfile]="isOwnArtistProfile"></app-artist-albums-list>
     </ng-container>
 
     <!-- Sección de canciones -->

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.html
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.html
@@ -10,7 +10,6 @@
   <!-- Artista sin canciones -->
   <div *ngIf="!loading && isOwnProfile && songs.length === 0" class="no-songs">
     No tienes canciones disponibles.
-    <button class="create-button-inline" (click)="openCreateForm()">Crear canción</button>
   </div>
 
   <!-- Lista de canciones -->

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -8,7 +8,7 @@
     <div class="search-bar">
       <input type="text" [(ngModel)]="searchTerm" (keyup.enter)="onSearch()" placeholder="Buscar canciones, artistas, usuarios...">
       <span *ngIf="errorMsg" style="color:red; font-size:12px;">{{ errorMsg }}</span>
-      <div *ngIf="showResults && (userResults.length || songResults.length || artistResults.length)" class="search-results">
+      <div *ngIf="showResults && (userResults.length || songResults.length || artistResults.length || albumResults.length)" class="search-results">
         <div *ngIf="userResults.length">
           <strong>Usuarios:</strong>
           <ul>
@@ -22,6 +22,14 @@
           <ul>
             <li *ngFor="let artist of artistResults">
               <a href="#" (click)="goToArtist(artist.name); $event.preventDefault()">{{ artist.name }}</a>
+            </li>
+          </ul>
+        </div>
+        <div *ngIf="albumResults.length">
+          <strong>Álbumes:</strong>
+          <ul>
+            <li *ngFor="let album of albumResults">
+              <a href="#" (click)="goToAlbum(album.id); $event.preventDefault()">{{ album.title }}</a>
             </li>
           </ul>
         </div>

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -11,6 +11,7 @@ import { catchError, forkJoin, of } from 'rxjs';
 import { ArtistResponse } from '../../../models/artist.model';
 import { ArtistService } from '../../../services/Artist.service';
 import { AuthService } from '../../../services/Auth.service';
+import { AlbumService } from '../../../services/Album.service';
 
 @Component({
   selector: 'app-navbar',
@@ -25,12 +26,14 @@ export class NavbarComponent {
   userResults: UserResponse[] = [];
   songResults: SongResponse[] = [];
   artistResults: ArtistResponse[] = [];
+  albumResults: any[] = [];
   showResults = false;
   constructor(
     private router: Router,
     private userService: UserService,
     private songService: SongService,
     private artistService: ArtistService,
+    private albumService: AlbumService,
     private authService: AuthService
   ) { }
   get isArtist(): boolean {
@@ -68,13 +71,14 @@ export class NavbarComponent {
     this.userResults = [];
     this.songResults = [];
     this.artistResults = [];
+    this.albumResults = [];
 
     forkJoin({
       user: this.userService.getUserByUsername(this.searchTerm.trim()).pipe(catchError(() => of(null))),
       songs: this.songService.getMySongs().pipe(catchError(() => of([]))),
-      artist: this.artistService.getArtistByName(this.searchTerm.trim()).pipe(catchError(() => of([])))
-    
-    }).subscribe(({ user, songs, artist }) => {
+      artist: this.artistService.getArtistByName(this.searchTerm.trim()).pipe(catchError(() => of([]))),
+      albums: this.albumService.getAlbumsByTitle(this.searchTerm.trim()).pipe(catchError(() => of([])))
+    }).subscribe(({ user, songs, artist, albums }) => {
       if (user) this.userResults = [user];
       if (artist && Array.isArray(artist) && artist.length > 0) {
         this.artistResults = artist;
@@ -84,7 +88,14 @@ export class NavbarComponent {
       if (songs && Array.isArray(songs)) {
         this.songResults = songs.filter(song => song.title.toLowerCase().includes(this.searchTerm.trim().toLowerCase()));
       }
-      if (!user && (!this.songResults || this.songResults.length === 0) && (!this.artistResults || this.artistResults.length === 0)) {
+      if (albums && Array.isArray(albums.data)) {
+        this.albumResults = albums.data;
+      } else if (Array.isArray(albums)) {
+        this.albumResults = albums;
+      } else {
+        this.albumResults = [];
+      }
+      if (!user && (!this.songResults || this.songResults.length === 0) && (!this.artistResults || this.artistResults.length === 0) && (!this.albumResults || this.albumResults.length === 0)) {
         this.errorMsg = 'No se encontraron resultados';
       }
       this.showResults = true;
@@ -117,6 +128,11 @@ export class NavbarComponent {
 
   goToArtist(artistName: string) {
     this.router.navigate(['/artist/profile-artist', artistName]);
+    this.showResults = false;
+  }
+
+  goToAlbum(albumId: number) {
+    this.router.navigate(['/album', albumId]);
     this.showResults = false;
   }
 

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -90,8 +90,6 @@ export class NavbarComponent {
       }
       if (albums && Array.isArray(albums.data)) {
         this.albumResults = albums.data;
-      } else if (Array.isArray(albums)) {
-        this.albumResults = albums;
       } else {
         this.albumResults = [];
       }


### PR DESCRIPTION
Mejoras en permisos y visibilidad de acciones sobre álbumes de artista

Objetivo:
Evitar que un usuario pueda crear, editar o eliminar álbumes de artistas que no le pertenecen, mostrando estas opciones solo al dueño del perfil de artista.

Cambios realizados
-  Control de permisos en la lista de álbumes:
- El componente 

ArtistAlbumsListComponent
- ahora recibe el input isOwnProfile para saber si el usuario autenticado es el dueño del perfil.
- Los botones de editar y eliminar álbum solo se muestran si isOwnProfile es true.

Botón de crear álbum:
- El botón para crear un nuevo álbum solo aparece cuando el usuario está viendo su propio perfil de artista.

Propagación de permisos desde el perfil:
- El componente de perfil de artista (ProfileArtistComponent) calcula si el perfil mostrado corresponde al usuario autenticado y pasa ese dato a los componentes hijos.
- Se asegura que tanto la lista de álbumes como la sección de canciones reciban el flag isOwnProfile correctamente.

UX mejorada:
- Al visitar el perfil de otro artista, solo se pueden visualizar los álbumes, sin opciones de edición, eliminación ni creación.
- El dueño del perfil mantiene acceso completo a la gestión de sus álbumes.