### PR TITLE
feat(song): integración de reproducción con YouTube desde artist-songs

### DIFF
--- a/src/app/features/song/pages/artist-songs/artist-songs.component.css
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.css
@@ -9,6 +9,23 @@
   align-items: flex-start;
 }
 
+.play-button {
+  background-color: #d80000;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  font-size: 16px;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: background-color 0.2s ease;
+}
+
+.play-button:hover {
+  background-color: #a50000;
+}
+
 .title {
   font-size: 2rem;
   color: #000000;

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.html
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.html
@@ -26,6 +26,15 @@
         </small>
       </div>
 
+<!-- Botón de Reproducir/Pausar si tiene URL -->
+        <div *ngIf="song.youtubeUrl" class="player-control">
+          <button (click)="togglePlay(i, song.youtubeUrl)" class="play-button" [title]="isPlaying[i] ? 'Pausar' : 'Reproducir'">
+            {{ isPlaying[i] ? '⏸️' : '▶️' }}
+          </button>
+          <!-- iframe oculto -->
+          <div id="yt-player-{{i}}" style="width: 0; height: 0; overflow: hidden;"></div>
+        </div>
+
       <!-- Acciones solo si es su perfil -->
       <div class="actions" *ngIf="isOwnProfile">
         <button (click)="toggleMenu(i)" class="menu-button" title="Opciones">&#8942;</button>
@@ -63,6 +72,15 @@
           [(ngModel)]="editingSong.isPublicSong"
           name="isPublicSong"
         />
+
+        <label for="youtubeUrl">Enlace de YouTube:</label>
+        <input
+          id="youtubeUrl"
+          type="text"
+          [(ngModel)]="editingSong.youtubeUrl"
+          name="youtubeUrl"
+        />
+
 
         <div class="form-buttons">
           <button type="submit" class="save-button">Guardar</button>

--- a/src/app/models/song.model.ts
+++ b/src/app/models/song.model.ts
@@ -2,6 +2,7 @@ export interface SongRequest {
   title: string;
   isPublicSong: boolean;
   artistId?: number; // Solo para admin
+  youtubeUrl: string;
 }
 
 export interface SongResponse {
@@ -12,4 +13,5 @@ export interface SongResponse {
   message: string;
   artistId: number;
   artistName: string;
+  youtubeUrl: string;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Manjari:wght@700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
### ✅ Descripción
Se integra la funcionalidad de reproducción de canciones desde enlaces de YouTube en la vista del artista.

### 📌 Cambios realizados
- Se añadió el botón de reproducción en `artist-songs.component.html`.
- Se integró la lógica de control `play/pause` con la API de YouTube en `artist-songs.component.ts`.
- Se añadió el campo `youtubeUrl` en el modelo `SongResponse`.
- Se actualizó `index.html` para cargar el script de YouTube (`iframe_api`).
- Estilos básicos para el botón de reproducción.

### 🎬 Funcionalidad
- El botón "▶️ / ⏸️" aparece si la canción tiene un `youtubeUrl`.
- Al dar clic, se reproduce el video en segundo plano (audio oculto).
- Puede reiniciarse al volver a reproducir.

### 🧪 Cómo probar
1. Crear una canción con un enlace de YouTube válido.
2. Verificar que aparece el botón de reproducción en la lista.
3. Reproducir, pausar y volver a iniciar la canción.

### 📎 Notas
Este cambio complementa el PR del backend que incluye el nuevo campo `youtubeUrl`.