### PR TITLE
feat(playlists): mejoras en gestión de accesos directos y borrado de playlists

### DIFF
--- a/src/app/features/home/home-page.component.html
+++ b/src/app/features/home/home-page.component.html
@@ -8,7 +8,7 @@
  <div class="playlists-grid">
     <div 
         class="playlist-card"
-        *ngFor="let playlist of shortcuts"
+        *ngFor="let playlist of playlists"
         tabindex="0"
         (click)="goToPlaylist(playlist.playlistId)"
         [attr.aria-label]="'Abrir playlist ' + playlist.name"
@@ -18,7 +18,7 @@
         ></div>
             <div class="playlist-info">
             <span class="playlist-name">{{ playlist.name }}</span>
-            <span class="playlist-owner"></span>
+            <span class="playlist-owner">{{playlist.owner}}</span>
             <button class="playlist-play-btn" 
             aria-label="Reproducir playlist"
             (click)="goToPlaylist(playlist.playlistId); $event.stopPropagation()">

--- a/src/app/features/home/home-page.component.ts
+++ b/src/app/features/home/home-page.component.ts
@@ -1,7 +1,10 @@
+import { ShortcutsService } from './../../services/shortcuts.service';
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { PlaylistResponse } from '../../models/playlist.model';
 import { Router } from '@angular/router';
+import { ShortcutsResponse } from '../../models/shortcuts.model';
+import { PlaylistSummaryResponse } from './../../models/playlist.model';
+import { AlbumResponse } from '../../models/album.model';
 
 @Component({
   standalone: true,
@@ -11,20 +14,40 @@ import { Router } from '@angular/router';
   styleUrl: './home-page.component.css'
 })
 export class HomePageComponent implements OnInit {
-  shortcuts: PlaylistResponse[] = [];
+  shortcuts: ShortcutsResponse[] = [];
+  playlists: PlaylistSummaryResponse[] = [];
+  albums : AlbumResponse[] = []; // actualizar  
   userId: number | null = null;
-  constructor(private router: Router) {}
+  shortcutsId: number | null = null;
+  error = '';
+  isLoading = false;
+  constructor(private router: Router,
+              private shortcutsService: ShortcutsService
+  ){}
 
-
-  ngOnInit() {
-    const auth = localStorage.getItem('auth');
-    if (auth) {
-      const authObj = JSON.parse(auth);
-      this.userId = authObj.user?.id || null;
-      const key = `shortcuts_${this.userId}`;
-      this.shortcuts = JSON.parse(localStorage.getItem(key) || '[]');
-    }
+  ngOnInit(): void {
+    this.loadShortcuts();
   }
+
+  loadShortcuts(): void {
+    this.isLoading = true;
+    this.error = '';
+    this.shortcutsService.getShortcutsByUser().subscribe({
+      next: (shortcuts) => {
+        this.shortcutsId = shortcuts.ShortcutsId;
+        this.playlists = shortcuts.Playlists;
+        this.albums = shortcuts.Albums;
+        this.isLoading = false;
+      },
+      error: (err) => {
+        this.error = 'Error al cargar los accesos directos';
+        this.isLoading = false;
+        console.error(err);
+      }
+    });
+  }
+  
+  
 
   goToPlaylist(playlistId: number) {
      this.router.navigate(['/playlist', playlistId]);

--- a/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.html
+++ b/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.html
@@ -2,6 +2,7 @@
 <div class="popup-menu" *ngIf="visible">
   <button class="menu-item" *ngIf="canEdit" (click)="edit.emit()">Editar Playlist</button>
   <button class="menu-item delete" *ngIf="canEdit" (click)="delete.emit()">Eliminar Playlist</button>
-  <button class="menu-item acceso-directo" (click)="addShortcut.emit()">Añadir a acceso directo</button>
+  <button class="menu-item acceso-directo" *ngIf="!isInShortcuts" (click)="addShortcut.emit()">Añadir a acceso directo</button>
+  <button class="menu-item borrar-acceso-directo" *ngIf="isInShortcuts" (click)="removeShortcut.emit()">Eliminar de acceso directo</button>
   <button class="close-btn" (click)="close.emit()" aria-label="Cerrar">&times;</button>
 </div>

--- a/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.html
+++ b/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.html
@@ -1,7 +1,7 @@
 <div class="popup-backdrop" *ngIf="visible" (click)="close.emit()"></div>
 <div class="popup-menu" *ngIf="visible">
-  <button class="menu-item" (click)="edit.emit()">Editar Playlist</button>
-  <button class="menu-item delete" (click)="delete.emit()">Eliminar Playlist</button>
+  <button class="menu-item" *ngIf="canEdit" (click)="edit.emit()">Editar Playlist</button>
+  <button class="menu-item delete" *ngIf="canEdit" (click)="delete.emit()">Eliminar Playlist</button>
   <button class="menu-item acceso-directo" (click)="addShortcut.emit()">Añadir a acceso directo</button>
   <button class="close-btn" (click)="close.emit()" aria-label="Cerrar">&times;</button>
 </div>

--- a/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.ts
+++ b/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.ts
@@ -14,5 +14,7 @@ export class PlaylistOptionsPopupComponent {
   @Output() addShortcut = new EventEmitter<void>();
   @Output() close = new EventEmitter<void>();
   @Input() canEdit = false; 
+  @Input() isInShortcuts = false;
+  @Output() removeShortcut = new EventEmitter<void>();
 }
 

--- a/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.ts
+++ b/src/app/features/playlist/components/playlist-options-popup/playlist-options-popup.component.ts
@@ -13,5 +13,6 @@ export class PlaylistOptionsPopupComponent {
   @Output() delete = new EventEmitter<void>();
   @Output() addShortcut = new EventEmitter<void>();
   @Output() close = new EventEmitter<void>();
+  @Input() canEdit = false; 
 }
 

--- a/src/app/features/playlist/pages/playlist-display/playlist-display.component.html
+++ b/src/app/features/playlist/pages/playlist-display/playlist-display.component.html
@@ -13,12 +13,13 @@
   <button class="shuffle-btn" title="Aleatorio">
     <span class="icon-shuffle"></span>
   </button>
-  <button class="options-btn" title="Más opciones" (click)="showMenu = true" *ngIf="canEdit()">
+  <button class="options-btn" title="Más opciones" (click)="showMenu = true">
     <span class="icon-options"><span></span></span>
   </button>
 </div>
   <app-playlist-options-popup
     [visible]="showMenu"
+    [canEdit]="canEdit()"
     (edit)="onEditPlaylist()"
     (delete)="onDeletePlaylist()"
     (addShortcut)="onAddToShortcut()"

--- a/src/app/features/playlist/pages/playlist-display/playlist-display.component.html
+++ b/src/app/features/playlist/pages/playlist-display/playlist-display.component.html
@@ -21,8 +21,10 @@
     [visible]="showMenu"
     [canEdit]="canEdit()"
     (edit)="onEditPlaylist()"
+    [isInShortcuts]="isInShortcuts()"
     (delete)="onDeletePlaylist()"
     (addShortcut)="onAddToShortcut()"
+    (removeShortcut)="onRemoveFromShortcut()"
     (close)="showMenu = false">
   </app-playlist-options-popup>
 

--- a/src/app/features/playlist/pages/playlist-display/playlist-display.component.ts
+++ b/src/app/features/playlist/pages/playlist-display/playlist-display.component.ts
@@ -1,3 +1,4 @@
+import { PlaylistSummaryResponse } from './../../../../models/playlist.model';
 import { ConfirmDeleteDialogComponent } from './../../components/borrar-playlist/confirm-delete-dialog.component';
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
@@ -34,6 +35,7 @@ export class PlaylistDisplayComponent implements OnInit {
   songs: SongResponse[] = [];
   selectedSongForPlaylist: SongResponse | null = null;
   showAddToPlaylistModal = false;
+  shortcutsPlaylists: PlaylistSummaryResponse[] = [];
 
   constructor(
             private playlistService: PlaylistService, 
@@ -59,6 +61,10 @@ export class PlaylistDisplayComponent implements OnInit {
       const authObj = JSON.parse(auth);
       this.userID = authObj.user?.id || null;
     }
+      this.shortcutService.playlists$.subscribe(playlists => {
+      this.shortcutsPlaylists = playlists;
+    });
+      this.shortcutService.getShortcutsByUser().subscribe();
     }
 
     onEditPlaylist() {
@@ -159,6 +165,7 @@ export class PlaylistDisplayComponent implements OnInit {
       this.shortcutService.addPlaylistToShortcuts(request).subscribe({
         next: (response) => {
           console.log('Playlist agregada a accesos directos:', response);
+          this.shortcutService.getShortcutsByUser().subscribe();
           this.showMenu = false;
           alert('Playlist agregada a accesos directos');
         },
@@ -168,6 +175,29 @@ export class PlaylistDisplayComponent implements OnInit {
         }
       });
     }
+
+    onRemoveFromShortcut() {
+    if (!this.playlist) return;
+    this.shortcutService.removePlaylistFromShortcuts(this.playlist.playlistId).subscribe({
+      next: () => {
+        this.shortcutService.getShortcutsByUser().subscribe();
+        this.showMenu = false;
+        alert('Playlist eliminada de accesos directos');
+      },
+      error: (err) => {
+        alert('No se pudo eliminar la playlist de accesos directos');
+      }
+    });
+  }
+
+  isInShortcuts(): boolean {
+    console.log('shortcutsPlaylists:', this.shortcutsPlaylists, 'playlist:', this.playlist);
+    return this.shortcutsPlaylists?.some(p => p.playlistId === this.playlist?.playlistId);
+  }
+
+   goToHome(): void  {
+    this.router.navigate(['/home']);
+  }
 }
 
 

--- a/src/app/models/playlist.model.ts
+++ b/src/app/models/playlist.model.ts
@@ -23,3 +23,10 @@ export interface UpdatePlaylistRequest {
     isPublic ?: boolean;
     url_image ?: string;
 }
+
+export interface PlaylistSummaryResponse {
+    playlistId: number;
+    name: string;
+    url_image?: string;
+    owner: string;
+}

--- a/src/app/models/shortcuts.model.ts
+++ b/src/app/models/shortcuts.model.ts
@@ -1,0 +1,13 @@
+import { AlbumResponse } from "./album.model";
+import { PlaylistSummaryResponse } from "./playlist.model";
+
+export interface AddPlaylistToShortcutsRequest {
+    playlistId: number 
+}
+
+export interface ShortcutsResponse {
+    ShortcutsId: number;
+    Playlists : PlaylistSummaryResponse[];
+    // cambiar por un album summary response o como lo manejes en el backend
+    Albums: AlbumResponse[];
+}

--- a/src/app/services/shortcuts.service.ts
+++ b/src/app/services/shortcuts.service.ts
@@ -1,11 +1,27 @@
+import { AddPlaylistToShortcutsRequest, ShortcutsResponse } from './../models/shortcuts.model';
 import { Injectable } from '@angular/core';
-import { PlaylistResponse } from '../models/playlist.model';
+import { Observable, map } from 'rxjs';
+import { ApiService } from './Api.service';
 
-@Injectable({ providedIn: 'root' })
-export class ShortcutService {
-  private shortcutsKey = 'shortcuts';
-  removeShortcut(playlistId: number) { 
-    
+@Injectable({
+   providedIn: 'root'
+})
+export class ShortcutsService {
+  private endpoint = '/shortcuts';
+  constructor(private api: ApiService) {}
+
+  addPlaylistToShortcuts(request: AddPlaylistToShortcutsRequest): Observable<ShortcutsResponse> {
+    return this.api.post<{ data: ShortcutsResponse }>(this.endpoint, request)
+      .pipe(map(response => response.data));
+  }
+
+  removePlaylistFromShortcuts(playlistId: number): Observable<void> {
+    return this.api.delete(`${this.endpoint}/${playlistId}`);
+  }
+
+  getShortcutsByUser(): Observable<ShortcutsResponse> {
+    return this.api.get<{ data: ShortcutsResponse }>(this.endpoint)
+      .pipe(map(response => response.data));
   }
 }
 

--- a/src/app/services/shortcuts.service.ts
+++ b/src/app/services/shortcuts.service.ts
@@ -2,11 +2,15 @@ import { AddPlaylistToShortcutsRequest, ShortcutsResponse } from './../models/sh
 import { Injectable } from '@angular/core';
 import { Observable, map } from 'rxjs';
 import { ApiService } from './Api.service';
+import { BehaviorSubject } from 'rxjs';
+import { PlaylistSummaryResponse } from '../models/playlist.model';
 
 @Injectable({
    providedIn: 'root'
 })
 export class ShortcutsService {
+  private playlistsSubject = new BehaviorSubject<PlaylistSummaryResponse[]>([]);
+  playlists$ = this.playlistsSubject.asObservable();
   private endpoint = '/shortcuts';
   constructor(private api: ApiService) {}
 
@@ -21,7 +25,14 @@ export class ShortcutsService {
 
   getShortcutsByUser(): Observable<ShortcutsResponse> {
     return this.api.get<{ data: ShortcutsResponse }>(this.endpoint)
-      .pipe(map(response => response.data));
+      .pipe(map(response => {
+         this.playlistsSubject.next(response.data.Playlists)
+        return  response.data
+      })
+    );
+  }
+  getCurrentShortcutsPlaylists(): PlaylistSummaryResponse[] {
+    return this.playlistsSubject.value;
   }
 }
 


### PR DESCRIPTION
## Descripción

Este PR implementa y mejora la gestión de accesos directos (shortcuts) para playlists en el frontend. Ahora la interfaz muestra dinámicamente el botón de agregar o eliminar de accesos directos según el estado real de la playlist, y se refresca automáticamente tras cada operación sin necesidad de redirigir al usuario. Además, se integra la eliminación automática del shortcut al borrar una playlist.

## Cambios principales

- Lógica para mostrar solo el botón correspondiente (agregar o eliminar de accesos directos) según si la playlist está en shortcuts.
- Refresco automático del estado de shortcuts tras agregar o eliminar una playlist.
- Mejor integración entre el estado compartido de `ShortcutsService` y `PlaylistDisplayComponent`.
- Eliminación automática del shortcut al borrar una playlist.
- Mejoras menores en la experiencia de usuario y manejo de errores.


