### PR TITLE
Fix/shortcuts playlist cover

### DIFF
--- a/src/app/features/home/home-page.component.html
+++ b/src/app/features/home/home-page.component.html
@@ -8,13 +8,13 @@
  <div class="playlists-grid">
     <div 
         class="playlist-card"
-        *ngFor="let playlist of playlists"
+        *ngFor="let playlist of playlists"    
         tabindex="0"
         (click)="goToPlaylist(playlist.playlistId)"
         [attr.aria-label]="'Abrir playlist ' + playlist.name"
     >
         <div class="playlist-cover"
-        [ngStyle]="{ 'background-image': playlist.url_image ? 'url(' + playlist.url_image + ')' : '' }" 
+        [ngStyle]="{ 'background-image': playlist.urlImage ? 'url(' + playlist.urlImage + ')' : '' }" 
         ></div>
             <div class="playlist-info">
             <span class="playlist-name">{{ playlist.name }}</span>

--- a/src/app/features/home/home-page.component.ts
+++ b/src/app/features/home/home-page.component.ts
@@ -53,4 +53,6 @@ export class HomePageComponent implements OnInit {
      this.router.navigate(['/playlist', playlistId]);
   }
 
+
+
 }

--- a/src/app/features/playlist/pages/playlist-display/playlist-display.component.css
+++ b/src/app/features/playlist/pages/playlist-display/playlist-display.component.css
@@ -20,30 +20,60 @@ body {
     padding: 0;
 }
 
+
+.playlist-cover-large {
+  width: 220px;
+  height: 220px;
+  min-width: 220px;
+  min-height: 220px;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.25);
+}
+
+.playlist-header-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  height: 100%;
+  padding-bottom: 24px;
+}
+
+.playlist-type {
+  font-size: 1rem;
+  color: #fff;
+  opacity: 0.8;
+  margin-bottom: 12px;
+  font-weight: 500;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
 .header {
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
-    padding: 40px;
-    position: relative;
     display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    height: 300px;
-    color: white;
+    flex-direction: row;
+    background: linear-gradient(to bottom, #2b0000, #550000);
+    padding: 40px 40px 32px 40px;
+    height: 320px;
+    box-sizing: border-box;
+    gap: 40px;    
 }
 
 .header h1 {
-    font-size: 3rem;
-    margin: 0;
+    font-size: 4rem;
+    margin: 0 0 18px 0;
     color: #fff;
     font-weight: bold;
+    line-height: 1.1;
 }
 
 .header .details {
-    font-size: 1rem;
+    font-size: 1.1rem;
     color: #fff;
-    opacity: 1;
+    opacity: 0.95;
+    margin-top: 8px;
 }
 
 .controls {

--- a/src/app/features/playlist/pages/playlist-display/playlist-display.component.html
+++ b/src/app/features/playlist/pages/playlist-display/playlist-display.component.html
@@ -1,11 +1,15 @@
 <div *ngIf="playlist && !loading" class="playlist-detail-root">
-  <div class="header" [ngStyle]="{'background-image': 'url(' + playlist.url_image + ')'}">
+  <div class="header">
+  <div class="playlist-cover-large"
+      [ngStyle]="{'background-image': 'url(' + playlist.url_image + ')'}">
+  </div>
+  <div class="playlist-header-info" >
     <h1>{{ playlist.name }}</h1>
     <div class="details">
-       {{ playlist.createdAt | date }} &bull; {{ playlist.songs.length }} Canciones
+       {{ playlist.createdAt | date }} &bull; {{ playlist.songs.length }} Canciones &bull; {{ playlist.description }}
     </div>
   </div>
-
+</div>
   <div class="controls">
   <button class="play-btn" title="Reproducir">
     <span class="icon-play"></span>

--- a/src/app/features/playlist/pages/playlist-display/playlist-display.component.ts
+++ b/src/app/features/playlist/pages/playlist-display/playlist-display.component.ts
@@ -190,8 +190,7 @@ export class PlaylistDisplayComponent implements OnInit {
     });
   }
 
-  isInShortcuts(): boolean {
-    console.log('shortcutsPlaylists:', this.shortcutsPlaylists, 'playlist:', this.playlist);
+  isInShortcuts(): boolean {  
     return this.shortcutsPlaylists?.some(p => p.playlistId === this.playlist?.playlistId);
   }
 

--- a/src/app/models/playlist.model.ts
+++ b/src/app/models/playlist.model.ts
@@ -27,6 +27,6 @@ export interface UpdatePlaylistRequest {
 export interface PlaylistSummaryResponse {
     playlistId: number;
     name: string;
-    url_image?: string;
+    urlImage?: string;
     owner: string;
 }


### PR DESCRIPTION
## Cambios incluidos

### 1. fix(playlists): corregido binding de imagen de portada usando urlImage en vez de url_image

- Se ajustó el nombre de la propiedad en el response y en el template para mostrar correctamente la imagen de portada de las playlists, incluyendo las de shortcuts de otros usuarios.

### 2. feat(ui): rediseño del header de playlist para estilo tipo Spotify

- Se actualizó el layout del header para mostrar la portada a la izquierda y la información a la derecha, replicando el estilo visual de Spotify.
- Se mejoró el CSS para que la imagen de portada tenga tamaño fijo, bordes redondeados y sombra.
- Se reorganizó la estructura HTML para mayor claridad y responsividad.

---

Ambos cambios mejoran la experiencia visual y la consistencia de la interfaz para el usuario.