### PR TITLE
feat(song-detail): vista de detalle de canciones y navegación desde perfiles

### DIFF
--- a/src/app/features/artist/pages/otherArtistProfile/otherArtistProfile.component.html
+++ b/src/app/features/artist/pages/otherArtistProfile/otherArtistProfile.component.html
@@ -23,4 +23,19 @@
   </section>
   <div *ngIf="artist.isActive"><span style="color:green;">Artista activo</span></div>
   <div *ngIf="!artist.isActive"><span style="color:red;">Artista inactivo</span></div>
+
+<!-- Canciones del artista -->
+<!-- Canciones del artista -->
+  <div class="artist-songs-section">
+    <div *ngIf="songsLoading">Cargando canciones...</div>
+    <div *ngIf="songsError && !songsLoading" style="color:red;">{{ songsError }}</div>
+    <div *ngIf="!songsLoading && songs.length === 0">Este artista no tiene canciones aún.</div>
+
+    <app-artist-songs
+      *ngIf="!songsLoading && songs.length > 0"
+      [songs]="songs"
+      [isOwnProfile]="false"
+    ></app-artist-songs>
+  </div>
+
 </div>

--- a/src/app/features/artist/pages/otherArtistProfile/otherArtistProfile.component.ts
+++ b/src/app/features/artist/pages/otherArtistProfile/otherArtistProfile.component.ts
@@ -1,13 +1,16 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { ArtistService } from '../../../../services/Artist.service';
 import { ArtistResponse } from '../../../../models/artist.model';
+import { SongResponse } from '../../../../models/song.model';
+import { SongService } from '../../../../services/Song.service';
+import { ArtistSongsComponent } from '../../../song/pages/artist-songs/artist-songs.component';
 
 @Component({
   selector: 'app-other-artist-profile',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ArtistSongsComponent],
   templateUrl: './otherArtistProfile.component.html',
   styleUrl: './otherArtistProfile.component.css',
 })
@@ -16,7 +19,11 @@ export class OtherArtistProfileComponent implements OnInit {
   loading = false;
   errorMsg = '';
 
-  constructor(private route: ActivatedRoute, private artistService: ArtistService) {}
+  songs: SongResponse[] = [];
+  songsLoading = true;
+  songsError = '';
+
+  constructor(private route: ActivatedRoute, private artistService: ArtistService, private songService: SongService) {}
 
   ngOnInit(): void {
     this.route.paramMap.subscribe(params => {
@@ -24,12 +31,23 @@ export class OtherArtistProfileComponent implements OnInit {
       if (idParam) {
         const id = Number(idParam);
         this.loading = true;
+
         this.artistService.getArtistById(id).subscribe({
           next: (artist) => {
             this.artist = Array.isArray(artist) ? artist[0] : artist;
             this.loading = false;
+
+            // 🔥 Obtener canciones públicas del artista
+            this.songService.getSongsByArtist(this.artist?.id!).subscribe({
+              next: (songs) => {
+                this.songs = songs;
+              },
+              error: () => {
+                this.songsError = 'No se pudieron cargar las canciones del artista.';
+              }
+            });
           },
-          error: (err) => {
+          error: () => {
             this.errorMsg = 'No se pudo cargar el perfil de artista.';
             this.loading = false;
           }

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.css
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.css
@@ -9,6 +9,31 @@
   align-items: flex-start;
 }
 
+.song-cover {
+  width: 60px;
+  height: 60px;
+  margin-right: 10px;
+  flex-shrink: 0;
+}
+
+.cover-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.cover-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  background-color: #eee;
+  color: #999;
+  border-radius: 8px;
+}
+
+
 .play-button {
   background-color: #d80000;
   color: white;
@@ -270,5 +295,34 @@ input[type='checkbox'] {
   color: #D80000;
   font-size: 0.9rem;
   margin-top: 0.5rem;
+  font-weight: bold;
+}
+
+.cover-preview-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.cover-preview {
+  width: 120px;
+  height: 120px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.upload-cover-label {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.upload-cover-button {
+  background-color: #D80000;
+  color: white;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
   font-weight: bold;
 }

--- a/src/app/features/song/pages/artist-songs/artist-songs.component.html
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.html
@@ -2,11 +2,6 @@
 
   <div *ngIf="loading">Cargando...</div>
 
-  <!-- Usuario no es artista (otro perfil) -->
-  <div *ngIf="!loading && !isOwnProfile" class="no-profile">
-    Este usuario no tiene un perfil de artista.
-  </div>
-
   <!-- Artista sin canciones -->
   <div *ngIf="!loading && isOwnProfile && songs.length === 0" class="no-songs">
     No tienes canciones disponibles.
@@ -15,6 +10,14 @@
   <!-- Lista de canciones -->
   <ul *ngIf="songs.length > 0">
     <li *ngFor="let song of songs; let i = index" class="song-item">
+      <!-- Portada de la canción -->
+    <div class="song-cover">
+      <img *ngIf="song.imageUrl; else noCover" [src]="song.imageUrl" alt="Portada de {{ song.title }}" class="cover-image" />
+      <ng-template #noCover>
+        <div class="cover-placeholder">📷</div>
+      </ng-template>
+    </div>
+
       <div class="song-info">
         <div class="song-title">
           <span class="song-index">{{ i + 1 }}.</span>
@@ -26,12 +29,11 @@
         </small>
       </div>
 
-<!-- Botón de Reproducir/Pausar si tiene URL -->
         <div *ngIf="song.youtubeUrl" class="player-control">
           <button (click)="togglePlay(i, song.youtubeUrl)" class="play-button" [title]="isPlaying[i] ? 'Pausar' : 'Reproducir'">
             {{ isPlaying[i] ? '⏸️' : '▶️' }}
           </button>
-          <!-- iframe oculto -->
+          
           <div id="yt-player-{{i}}" style="width: 0; height: 0; overflow: hidden;"></div>
         </div>
 
@@ -49,38 +51,35 @@
 
   <button *ngIf="isOwnProfile" class="create-song-button" (click)="openCreateForm()"> Crear canción </button>
 
-  <!-- Modal Crear/Editar -->
   <div *ngIf="showSongForm" class="modal">
     <div class="modal-content">
       <h2>{{ editingSong.id ? 'Editar canción' : 'Crear canción' }}</h2>
       <form (submit)="onSubmit($event)">
+
+        <!-- Vista previa de imagen -->
+        <div class="cover-preview-container">
+          <img *ngIf="editingSong.imageUrl; else noImage" [src]="editingSong.imageUrl" class="cover-preview" alt="Portada" />
+          <ng-template #noImage>
+            <div class="cover-placeholder">📷</div>
+          </ng-template>
+        </div>
+
+<!-- Botón para subir portada -->
+        <label class="upload-cover-label">
+        <input type="file" accept="image/*" (change)="onImageSelected($event)" hidden />
+        <span class="upload-cover-button">Subir portada</span>
+        </label>
+
         <label for="title">Título:</label>
-        <input
-          id="title"
-          type="text"
-          [(ngModel)]="editingSong.title"
-          name="title"
-          required
-        />
+        <input id="title" type="text" [(ngModel)]="editingSong.title" name="title" required />
 
         <div class="form-error" *ngIf="formError">{{ formError }}</div>
 
         <label for="isPublicSong">¿Es pública?</label>
-        <input
-          id="isPublicSong"
-          type="checkbox"
-          [(ngModel)]="editingSong.isPublicSong"
-          name="isPublicSong"
-        />
+        <input id="isPublicSong" type="checkbox" [(ngModel)]="editingSong.isPublicSong" name="isPublicSong" />
 
-        <label for="youtubeUrl">Enlace de YouTube:</label>
-        <input
-          id="youtubeUrl"
-          type="text"
-          [(ngModel)]="editingSong.youtubeUrl"
-          name="youtubeUrl"
-        />
-
+        <label for="youtubeUrl">Enlace de la canción:</label>
+        <input id="youtubeUrl" type="text" [(ngModel)]="editingSong.youtubeUrl" name="youtubeUrl" />
 
         <div class="form-buttons">
           <button type="submit" class="save-button">Guardar</button>

--- a/src/app/features/song/pages/song-detail/song-detail.component.css
+++ b/src/app/features/song/pages/song-detail/song-detail.component.css
@@ -1,0 +1,53 @@
+.song-detail-container {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.song-title {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.song-detail-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.song-cover {
+  width: 220px;
+  height: 220px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+.song-info {
+  text-align: center;
+}
+
+.play-button,
+.add-to-playlist-btn {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #d80000;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.play-button:hover,
+.add-to-playlist-btn:hover {
+  background-color: #a30000;
+}
+
+.loading-text,
+.error-text {
+  text-align: center;
+  margin-top: 2rem;
+  font-weight: bold;
+  color: gray;
+}

--- a/src/app/features/song/pages/song-detail/song-detail.component.html
+++ b/src/app/features/song/pages/song-detail/song-detail.component.html
@@ -1,0 +1,33 @@
+<div class="song-detail-container" *ngIf="!loading && song">
+  <h2 class="song-title">🎵 {{ song.title }}</h2>
+
+  <div class="song-detail-card">
+    <img [src]="safeImageUrl" alt="Portada" class="song-cover" />
+
+    <div class="song-info">
+      <p><strong>Artista:</strong> {{ song.artistName }}</p>
+      <p><strong>Fecha de lanzamiento:</strong> {{ song.releaseDate | date:'dd/MM/yyyy' }}</p>
+
+      <div class="player-control" *ngIf="song.youtubeUrl">
+        <button (click)="togglePlay()" class="play-button">
+          {{ isPlaying ? '⏸️ Pausar' : '▶️ Reproducir' }}
+        </button>
+
+        <!-- 👇 El id debe coincidir con el usado en el .ts: 'yt-player-detail' -->
+        <div id="yt-player-detail" style="width: 0; height: 0; overflow: hidden;"></div>
+      </div>
+
+      <button (click)="openAddToPlaylist(song)" class="add-to-playlist-btn">➕ Agregar a playlist</button>
+    </div>
+  </div>
+</div>
+
+<app-add-song-to-playlist-modal
+  *ngIf="showAddToPlaylistModal && selectedSongForPlaylist"
+  [songId]="selectedSongForPlaylist.id"
+  (close)="onCloseAddToPlaylist()"
+  (songAdded)="onSongAddedToPlaylist()">
+</app-add-song-to-playlist-modal>
+
+<div *ngIf="loading" class="loading-text">Cargando canción...</div>
+<div *ngIf="error" class="error-text">{{ error }}</div>

--- a/src/app/features/song/pages/song-detail/song-detail.component.ts
+++ b/src/app/features/song/pages/song-detail/song-detail.component.ts
@@ -1,0 +1,125 @@
+import { Component, OnInit } from '@angular/core';
+import { SongResponse } from '../../../../models/song.model';
+import { SongService } from '../../../../services/Song.service';
+import { ActivatedRoute } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { AddSongToPlaylistModalComponent } from '../../../playlist/components/agregar-cancion-playlist/add-song-to-playlist.component';
+
+@Component({
+  selector: 'app-song-detail',
+  standalone: true,
+  imports: [CommonModule, AddSongToPlaylistModalComponent],
+  templateUrl: './song-detail.component.html',
+  styleUrls: ['./song-detail.component.css']
+})
+export class SongDetailComponent implements OnInit {
+  songId!: number;
+  song!: SongResponse;
+  loading = true;
+  error = '';
+  apiReady = false;
+
+  selectedSongForPlaylist: SongResponse | null = null;
+  showAddToPlaylistModal = false;
+
+  isPlaying = false;
+  playerRef: any;
+
+  constructor(
+    private route: ActivatedRoute,
+    private songService: SongService
+  ) {}
+
+  ngOnInit(): void {
+  if (!(window as any).YT) {
+    (window as any).onYouTubeIframeAPIReady = () => {
+      this.apiReady = true;
+      this.subscribeToRouteChanges(); // escuchar cambios
+    };
+  } else {
+    this.apiReady = true;
+    this.subscribeToRouteChanges(); // escuchar cambios
+  }
+}
+
+subscribeToRouteChanges(): void {
+  this.route.paramMap.subscribe(params => {
+    this.songId = Number(params.get('id'));
+    this.loadSong();
+  });
+}
+
+  loadSong(): void {
+    this.songId = Number(this.route.snapshot.paramMap.get('id'));
+
+    if (this.songId) {
+      this.songService.getSongById(this.songId).subscribe({
+        next: (data) => {
+          this.song = data;
+          this.loading = false;
+
+          const videoId = this.extractVideoId(this.song.youtubeUrl);
+          if (videoId && this.apiReady) {
+            this.initYouTubePlayer(videoId);
+          }
+        },
+        error: (err) => {
+          this.error = 'No se pudo cargar la canción';
+          this.loading = false;
+        }
+      });
+    }
+  }
+
+  extractVideoId(url: string): string {
+    const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    return match ? match[1] : '';
+  }
+
+  initYouTubePlayer(videoId: string): void {
+    setTimeout(() => {
+      this.playerRef = new (window as any).YT.Player('yt-player-detail', {
+        videoId,
+        height: '0',
+        width: '0',
+        events: {
+          onReady: () => {
+            console.log('Player ready');
+          }
+        }
+      });
+    }, 100);
+  }
+
+  togglePlay(): void {
+    if (!this.playerRef) return;
+
+    if (this.isPlaying) {
+      this.playerRef.pauseVideo();
+      this.isPlaying = false;
+    } else {
+      this.playerRef.seekTo(0);
+      this.playerRef.playVideo();
+      this.isPlaying = true;
+    }
+  }
+
+  openAddToPlaylist(song: SongResponse) {
+    this.selectedSongForPlaylist = song;
+    this.showAddToPlaylistModal = true;
+  }
+
+  onCloseAddToPlaylist() {
+    this.showAddToPlaylistModal = false;
+    this.selectedSongForPlaylist = null;
+  }
+
+  onSongAddedToPlaylist() {
+    this.showAddToPlaylistModal = false;
+    this.selectedSongForPlaylist = null;
+  }
+
+  get safeImageUrl(): string {
+    return this.song?.imageUrl || 'https://res.cloudinary.com/dqk8inmwe/image/upload/v1750800568/pfp_placeholder_hwwumb.jpg';
+  }
+}

--- a/src/app/features/song/song.routes.ts
+++ b/src/app/features/song/song.routes.ts
@@ -5,5 +5,12 @@ export const SONG_ROUTES: Routes = [
   {
     path: 'my-songs',
     component: ArtistSongsComponent
+  },
+  {
+    path: 'detail/:id',
+    loadComponent: () =>
+      import('./pages/song-detail/song-detail.component').then(
+        (m) => m.SongDetailComponent
+      )
   }
 ];

--- a/src/app/models/song.model.ts
+++ b/src/app/models/song.model.ts
@@ -3,6 +3,7 @@ export interface SongRequest {
   isPublicSong: boolean;
   artistId?: number; // Solo para admin
   youtubeUrl: string;
+  imageUrl?: string;
 }
 
 export interface SongResponse {
@@ -14,4 +15,5 @@ export interface SongResponse {
   artistId: number;
   artistName: string;
   youtubeUrl: string;
+  imageUrl?: string;
 }

--- a/src/app/services/Song.service.ts
+++ b/src/app/services/Song.service.ts
@@ -26,4 +26,17 @@ export class SongService {
   deleteSong(id: number): Observable<void> {
     return this.api.delete(`${this.endpoint}/${id}`);
   }
+
+  searchPublicSongsByTitle(title: string): Observable<SongResponse[]> {
+    return this.api.get<SongResponse[]>(`/songs/search?title=${encodeURIComponent(title)}`);
+  }
+
+  getSongsByArtist(artistId: number): Observable<SongResponse[]> {
+    return this.api.get<SongResponse[]>(`${this.endpoint}/by-artist?artistId=${artistId}`);
+  }
+
+  getSongById(id: number): Observable<SongResponse> {
+    return this.api.get<SongResponse>(`/songs/${id}`);
+  }
+
 }

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -104,7 +104,7 @@ export class NavbarComponent {
 
     forkJoin({
       user: this.userService.getUserByUsername(this.searchTerm.trim()).pipe(catchError(() => of(null))),
-      songs: this.songService.getMySongs().pipe(catchError(() => of([]))),
+      songs: this.songService.searchPublicSongsByTitle(this.searchTerm.trim()).pipe(catchError(() => of([]))),
       artist: this.artistService.getArtistByName(this.searchTerm.trim()).pipe(catchError(() => of([]))),
       albums: this.albumService.getAlbumsByTitle(this.searchTerm.trim()).pipe(catchError(() => of([]))),
       playlists: this.playlistService.getPublicPlaylistsByName(this.searchTerm.trim()).pipe(catchError(() => of([])))
@@ -157,9 +157,10 @@ export class NavbarComponent {
   }
 
   goToSong(songId: number) {
-    this.router.navigate(['/songs', songId]);
-    this.showResults = false;
-  }
+  this.router.navigate(['/songs/detail', songId]);
+  this.showResults = false;
+  this.searchTerm = '';
+}
 
   goToArtist(artistName: string) {
     this.router.navigate(['/artist/profile-artist', artistName]);


### PR DESCRIPTION
Este PR implementa la vista de detalle de una canción, permitiendo mostrar su información completa, imagen de portada y reproducirla. Incluye lo siguiente:

📌 Nuevo componente SongDetailComponent que permite visualizar:

Imagen de portada

Título, artista y fecha de lanzamiento

Reproductor de YouTube integrado con botones de reproducción/pausa

Botón para añadir a una playlist

🧭 Se agrega la ruta songs/detail/:id en song.routes.ts

🧠 Actualización del servicio SongService para incluir el método getSongById

🛠️ Ajustes en artist-songs y otherArtistProfile para permitir navegar a la vista de detalle desde las canciones listadas