### PR TITLE
Nueva búsqueda en la biblioteca de playlists

### DIFF
--- a/src/app/features/playlist/pages/biblioteca/bibiloteca.component.ts
+++ b/src/app/features/playlist/pages/biblioteca/bibiloteca.component.ts
@@ -5,6 +5,8 @@ import { NgIf, NgFor, NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CreatePlaylistDialogComponent } from '../../components/crear-playlist/crear-playlist.component';
 import { Router } from '@angular/router';
+import { debounceTime, distinctUntilChanged } from 'rxjs';
+import { Subject } from 'rxjs';
 @Component({
   selector: 'app-playlist-library',
   standalone: true,
@@ -15,11 +17,11 @@ import { Router } from '@angular/router';
 })
 export class PlaylistLibraryComponent implements OnInit {
   playlists: PlaylistResponse[] = [];
-  filteredPlaylists: PlaylistResponse[] = [];
   isLoading = false;
   error = '';
   searchQuery = '';
   showCreateDialog = false;
+  searchQueryChanged = new Subject<string>(); 
 
   constructor(private playlistService: PlaylistService, 
               private cdr: ChangeDetectorRef,
@@ -28,6 +30,12 @@ export class PlaylistLibraryComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadPlaylists();
+    this.searchQueryChanged.pipe(
+      debounceTime(350),           // Espera 350 ms tras dejar de tipear
+      distinctUntilChanged()       // Solo emite si cambió el texto
+    ).subscribe(q => {
+      this.onSearchReal(q);
+    });
   }
 
   loadPlaylists(): void {
@@ -36,7 +44,6 @@ export class PlaylistLibraryComponent implements OnInit {
     this.playlistService.getMyPlaylists().subscribe({
       next: (playlists) => {
         this.playlists = playlists;
-        this.applyFilter();
         this.isLoading = false;
         this.cdr.markForCheck(); 
       },
@@ -49,26 +56,30 @@ export class PlaylistLibraryComponent implements OnInit {
     });
   }
 
-  onSearch(): void {
-    const q = this.searchQuery.trim().toLowerCase();
-    if (!q) {
-      this.filteredPlaylists = this.playlists;
-    } else {
-      this.filteredPlaylists = this.playlists.filter(p =>
-        p.name.toLowerCase().includes(q)
-      );
-    }
-    this.cdr.markForCheck(); 
+
+   onSearch(): void {
+    this.searchQueryChanged.next(this.searchQuery);
   }
 
-  applyFilter(): void {
-    const q = this.searchQuery.trim().toLowerCase();
-    if (!q) {
-      this.filteredPlaylists = this.playlists;
+  onSearchReal(q: string): void {
+    const query = q.trim();
+    if (!query) {
+      this.loadPlaylists();
     } else {
-      this.filteredPlaylists = this.playlists.filter(p =>
-        p.name.toLowerCase().includes(q)
-      );
+      this.isLoading = true;
+      this.error = '';
+      this.playlistService.searchMyPlaylistsByName(query).subscribe({
+        next: (playlists) => {
+          this.playlists = playlists;
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: (err) => {
+          this.error = 'Error en la búsqueda de playlists';
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        }
+      });
     }
   }
 
@@ -82,7 +93,6 @@ export class PlaylistLibraryComponent implements OnInit {
 
   onPlaylistCreated(newPlaylist: PlaylistResponse) {
     this.playlists = [newPlaylist, ...this.playlists];
-    this.applyFilter();  
     this.showCreateDialog = false;
   }
   goToPlaylist(playlistId: number | string): void  {

--- a/src/app/features/playlist/pages/biblioteca/biblioteca.component.html
+++ b/src/app/features/playlist/pages/biblioteca/biblioteca.component.html
@@ -23,15 +23,15 @@
    <div *ngIf="isLoading" class="loading-state">Cargando...</div>
   <div *ngIf="error" class="error-state">{{ error }}</div>
 
-  <div *ngIf="!isLoading && !error && filteredPlaylists.length === 0" class="empty-state">
+  <div *ngIf="!isLoading && !error && playlists.length === 0" class="empty-state">
     No tienes playlists aún.
   </div>
 
 
-  <div class="playlists-grid" *ngIf="filteredPlaylists.length > 0">
+  <div class="playlists-grid" *ngIf="playlists.length > 0">
     <div 
     class="playlist-card"
-    *ngFor="let playlist of filteredPlaylists"
+    *ngFor="let playlist of playlists"
     tabindex="0"
     
     (click)="goToPlaylist(playlist.playlistId)"

--- a/src/app/services/playlist.service.ts
+++ b/src/app/services/playlist.service.ts
@@ -52,7 +52,7 @@ export class PlaylistService {
 }
 
   // 8. Obtener playlist propia por nombre (autenticado)
-  getMyPlaylistByName(playlistName: string): Observable<PlaylistResponse> {
+  getPlaylistByName(playlistName: string): Observable<PlaylistResponse> {
     return this.api.get<{ data: PlaylistResponse }>(`${this.endpoint}/by-name/${playlistName}`)
       .pipe(map(response => response.data));
   }
@@ -67,6 +67,13 @@ export class PlaylistService {
     return this.api.patch<{ data: PlaylistResponse }>(`${this.endpoint}/${playlistId}`, request)
       .pipe(map(response => response.data));
   }
+
+  searchMyPlaylistsByName(query: string): Observable<PlaylistResponse[]> {
+    return this.api.get<{ data: PlaylistResponse[] }>(
+      `${this.endpoint}/mine/search?name=${encodeURIComponent(query)}`
+    ).pipe(map(res => res.data));
+  }
+
 }
   
 


### PR DESCRIPTION
## Descripción

Este PR implementa una nueva funcionalidad de búsqueda en la vista de biblioteca de playlists. Ahora los usuarios pueden buscar sus playlists por nombre de manera eficiente y reactiva.

## Cambios principales

- Se agregó un input de búsqueda con debounce para evitar llamadas innecesarias al backend.
- La búsqueda se realiza en tiempo real mientras el usuario escribe.
- Si el campo de búsqueda está vacío, se muestran todas las playlists del usuario.
- Mejor manejo de estados de carga y error.
- Se mantiene la experiencia fluida y responsiva gracias a ChangeDetectionStrategy.OnPush.

## ¿Cómo probar?

1. Ve a la sección "Biblioteca".
2. Escribe el nombre de una playlist en el campo de búsqueda.
3. Observa cómo los resultados se filtran automáticamente.
4. Borra el texto para volver a ver todas tus playlists.

---

