### PR TITLE
 fix: Diferenciación entre estados vacíos en biblioteca de playlists

### DIFF
--- a/src/app/features/playlist/pages/biblioteca/bibiloteca.component.ts
+++ b/src/app/features/playlist/pages/biblioteca/bibiloteca.component.ts
@@ -22,6 +22,7 @@ export class PlaylistLibraryComponent implements OnInit {
   searchQuery = '';
   showCreateDialog = false;
   searchQueryChanged = new Subject<string>(); 
+  isSearching = false;
 
   constructor(private playlistService: PlaylistService, 
               private cdr: ChangeDetectorRef,
@@ -61,13 +62,15 @@ export class PlaylistLibraryComponent implements OnInit {
     this.searchQueryChanged.next(this.searchQuery);
   }
 
-  onSearchReal(q: string): void {
-    const query = q.trim();
-    if (!query) {
+  onSearchReal(query: string): void {
+    this.isSearching = query.trim() !== '';
+    this.isLoading = true;
+    this.error = '';
+
+    if (query.trim() === '') {
       this.loadPlaylists();
-    } else {
-      this.isLoading = true;
-      this.error = '';
+      return;
+    } 
       this.playlistService.searchMyPlaylistsByName(query).subscribe({
         next: (playlists) => {
           this.playlists = playlists;
@@ -79,9 +82,9 @@ export class PlaylistLibraryComponent implements OnInit {
           this.isLoading = false;
           this.cdr.markForCheck();
         }
-      });
-    }
+    });
   }
+  
 
   onOpenCreateDialog() {
   this.showCreateDialog = true;

--- a/src/app/features/playlist/pages/biblioteca/biblioteca.component.html
+++ b/src/app/features/playlist/pages/biblioteca/biblioteca.component.html
@@ -23,10 +23,13 @@
    <div *ngIf="isLoading" class="loading-state">Cargando...</div>
   <div *ngIf="error" class="error-state">{{ error }}</div>
 
-  <div *ngIf="!isLoading && !error && playlists.length === 0" class="empty-state">
+  <div *ngIf="!isLoading && !error && playlists.length === 0 && !isSearching" class="empty-state">
     No tienes playlists aún.
   </div>
 
+  <div *ngIf="!isLoading && !error && playlists.length === 0 && isSearching" class="empty-state">
+    No se encontraron coincidencias
+  </div>
 
   <div class="playlists-grid" *ngIf="playlists.length > 0">
     <div 


### PR DESCRIPTION
## Descripción

Este PR mejora la experiencia de usuario al diferenciar claramente entre dos estados vacíos en la biblioteca de playlists: cuando el usuario no tiene playlists creadas vs cuando está buscando pero no hay coincidencias.

## Cambios principales

- Se agregó la variable `isSearching` para rastrear si hay una búsqueda activa.
- Se diferenciaron los mensajes de estado vacío:
  - **Sin playlists**: "No tienes playlists aún."
  - **Sin coincidencias de búsqueda**: "No se encontraron coincidencias"
- Mejor experiencia de usuario al mostrar mensajes contextuales apropiados.

- - - 