### PR TITLE
feat(admin): módulo de gestión de canciones (crear, editar, eliminar y filtrar)

### DIFF
--- a/src/app/features/admin/admin.routes.ts
+++ b/src/app/features/admin/admin.routes.ts
@@ -5,6 +5,7 @@ import { AdminGenresComponent } from './pages/admin-genres/admin-genres.componen
 import { AdminUsersComponent } from './pages/admin-users/admin-users.component';
 import { AdminRolesComponent } from './pages/admin-roles/admin-roles.component';
 import { AdminArtistsComponent } from './pages/admin-artists/admin-artists.component';
+import { AdminSongsComponent } from './pages/admin-songs/admin-songs.component';
 
 export const ADMIN_ROUTES: Routes = [
   { 
@@ -26,5 +27,9 @@ export const ADMIN_ROUTES: Routes = [
   { 
     path: 'roles', 
     component: AdminRolesComponent
+  },
+  {
+    path: 'songs',
+    component: AdminSongsComponent
   }
 ];

--- a/src/app/features/admin/pages/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/features/admin/pages/admin-dashboard/admin-dashboard.component.ts
@@ -42,6 +42,14 @@ export class AdminDashboardComponent {
       icon: '🔐',
       route: '/admin/roles',
       color: '#C62828'
+    },
+    {
+      id: 'canciones',
+      title: 'Gestión de Canciones',
+      description: 'Crear, editar y eliminar canciones',
+      icon: '🎤',
+      route: '/admin/songs',
+      color: '#C62828'
     }
   ];
 

--- a/src/app/features/admin/pages/admin-songs/admin-songs.component.css
+++ b/src/app/features/admin/pages/admin-songs/admin-songs.component.css
@@ -1,0 +1,495 @@
+.admin-section-container {
+  min-height: 100vh;
+  padding: 2rem;
+  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.section-header {
+  max-width: 1200px;
+  margin: 0 auto 3rem auto;
+  text-align: center;
+}
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: white;
+  border: 1px solid #B71C1C;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #B71C1C;
+  transition: all 0.3s ease;
+  margin-bottom: 2rem;
+}
+
+.back-btn:hover {
+  background: #B71C1C;
+  color: white;
+  transform: translateX(-2px);
+}
+
+.section-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #B71C1C;
+  margin-bottom: 0.5rem;
+  text-shadow: 0 2px 4px rgba(183, 28, 28, 0.3);
+}
+
+.section-subtitle {
+  font-size: 1.1rem;
+  color: #6c757d;
+  font-weight: 400;
+}
+
+.actions-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 2rem;
+}
+
+.create-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #B71C1C;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.create-btn:hover:not(:disabled) {
+  background: #8B0000;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(183, 28, 28, 0.3);
+}
+
+.create-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.loading-container, .empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(183, 28, 28, 0.15);
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #B71C1C;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1rem auto;
+}
+
+.empty-icon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+}
+
+.empty-state h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #B71C1C;
+  margin-bottom: 0.5rem;
+}
+
+.empty-state p {
+  color: #6c757d;
+  margin-bottom: 2rem;
+}
+
+.users-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: 1.5rem;
+}
+
+.user-card {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 20px rgba(183, 28, 28, 0.15);
+  border: 2px solid rgba(183, 28, 28, 0.1);
+  transition: all 0.3s ease;
+  animation: slideUp 0.6s ease-out;
+}
+
+.user-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 30px rgba(183, 28, 28, 0.2);
+}
+
+.user-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.user-avatar img {
+  width: 80px;
+  height: 80px;
+  border-radius: 8px; /* ahora es cuadrada */
+  object-fit: cover;
+  border: 3px solid rgba(183, 28, 28, 0.1);
+}
+
+.user-info {
+  flex: 1;
+}
+
+.user-name {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #B71C1C;
+  margin: 0 0 0.25rem 0;
+}
+
+.user-email {
+  font-size: 0.9rem;
+  color: #6c757d;
+  margin: 0 0 0.5rem 0;
+}
+
+.status-badge {
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.status-badge.active {
+  background: #E8F5E8;
+  color: #2E7D32;
+}
+
+.status-badge.inactive {
+  background: #FFEBEE;
+  color: #C62828;
+}
+
+.user-description p {
+  color: #495057;
+  line-height: 1.5;
+  margin: 0;
+  font-style: normal; /* sin cursiva */
+  font-weight: 500; /* peso medio */
+}
+
+.user-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  justify-content: center; /* botones centrados */
+}
+
+.edit-btn, .toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: none;
+  font-weight: 500;
+}
+
+.edit-btn {
+  background: #E3F2FD;
+  color: #1976D2;
+}
+
+.edit-btn:hover:not(:disabled) {
+  background: #BBDEFB;
+}
+
+.toggle-btn.deactivate {
+  background: #FFEBEE;
+  color: #C62828;
+}
+
+.toggle-btn.deactivate:hover:not(:disabled) {
+  background: #FFCDD2;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.3s ease;
+}
+
+.modal-card {
+  background: white;
+  border-radius: 16px;
+  padding: 2rem;
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  animation: slideUp 0.3s ease;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #eee;
+}
+
+.modal-header h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #B71C1C;
+  margin: 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  color: #999;
+  cursor: pointer;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.close-btn:hover {
+  background: #f5f5f5;
+  color: #666;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  color: #333;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: all 0.3s ease;
+  box-sizing: border-box;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 2rem;
+}
+
+.cancel-btn, .submit-btn {
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  border: none;
+}
+
+.cancel-btn {
+  background: transparent;
+  color: #6c757d;
+  border: 1px solid #ddd;
+}
+
+.cancel-btn:hover {
+  background: #f8f9fa;
+  color: #495057;
+}
+
+.submit-btn {
+  background: #B71C1C;
+  color: white;
+}
+
+.submit-btn:hover:not(:disabled) {
+  background: #8B0000;
+}
+
+.submit-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.image-upload-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.image-preview {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border: 2px dashed #ddd;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f8f9fa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.upload-placeholder {
+  text-align: center;
+  color: #6c757d;
+  font-size: 0.85rem;
+}
+
+.upload-btn {
+  background: #B71C1C;
+  color: white;
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+  width: fit-content;
+  transition: all 0.3s ease;
+}
+
+.upload-btn:hover {
+  background: #8B0000;
+}
+
+.upload-overlay {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(255, 255, 255, 0.9);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 10px;
+}
+
+.upload-overlay .spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid #f3f3f3;
+  border-top: 2px solid #B71C1C;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes spin {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(360deg); }
+}
+
+.form-group select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background-color: white;
+  color: #333;
+  transition: all 0.3s ease;
+  appearance: none; /* elimina el estilo nativo */
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 1.2rem;
+  cursor: pointer;
+}
+
+.form-group select:focus {
+  border-color: #B71C1C;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(183, 28, 28, 0.2);
+}
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+}
+
+.filter-bar label {
+  font-weight: 500;
+  color: #333;
+}
+
+.filter-bar select {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  font-size: 1rem;
+  background-color: white;
+  color: #333;
+}

--- a/src/app/features/admin/pages/admin-songs/admin-songs.component.html
+++ b/src/app/features/admin/pages/admin-songs/admin-songs.component.html
@@ -1,0 +1,133 @@
+<div class="admin-section-container">
+  <!-- Header -->
+  <div class="section-header">
+    <button class="back-btn" (click)="goBack()">← Volver</button>
+    <h2 class="section-title">Gestión de Canciones</h2>
+    <p class="section-subtitle">Crea, edita o elimina canciones como administrador</p>
+  </div>
+
+  <!-- Botón crear -->
+  <div class="actions-bar">
+    <button class="create-btn" (click)="openCreateForm()">+ Nueva Canción</button>
+  </div>
+
+  <div class="filter-bar">
+  <label for="sortSelect">Ordenar por:</label>
+  <select id="sortSelect" [(ngModel)]="selectedSort" (change)="sortSongs()">
+    <option value="newest">Más nuevo primero</option>
+    <option value="oldest">Más antiguo primero</option>
+    <option value="title">Título A-Z</option>
+  </select>
+</div>
+
+  <!-- Loading -->
+  <div *ngIf="loading" class="loading-container">
+    <div class="spinner"></div>
+    <p>Cargando canciones...</p>
+  </div>
+
+  <!-- Estado vacío -->
+  <div *ngIf="!loading && songs.length === 0" class="empty-state">
+    <div class="empty-icon">🎵</div>
+    <h3>No hay canciones registradas</h3>
+    <p>Haz clic en el botón para añadir una nueva canción</p>
+  </div>
+
+  <!-- Tarjetas -->
+  <div class="users-grid" *ngIf="songs.length > 0">
+    <div class="user-card" *ngFor="let song of songs">
+      <div class="user-header">
+        <div class="user-avatar">
+          <img [src]="getImageUrl(song.imageUrl)" alt="Portada">
+        </div>
+        <div class="user-info">
+          <h4 class="user-name">{{ song.title }}</h4>
+          <p class="user-email">{{ song.artistName }}</p>
+          <span class="status-badge" [class.active]="song.isPublicSong" [class.inactive]="!song.isPublicSong">
+            {{ song.isPublicSong ? 'Pública' : 'Privada' }}
+          </span>
+        </div>
+      </div>
+
+      <div class="user-description">
+        <p><strong>Fecha de lanzamiento:</strong> {{ song.releaseDate | date:'dd/MM/yyyy' }}</p>
+      </div>
+
+      <div class="user-actions">
+        <button class="edit-btn" (click)="openEditForm(song)">Editar</button>
+        <button class="toggle-btn deactivate" (click)="deleteSong(song.id)">Eliminar</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Crear / Editar -->
+  <div class="modal-overlay" *ngIf="showCreateForm || showEditForm">
+    <div class="modal-card">
+      <div class="modal-header">
+        <h3>{{ showCreateForm ? 'Crear Canción' : 'Editar Canción' }}</h3>
+        <button class="close-btn" (click)="closeForms()">×</button>
+      </div>
+
+      <form [formGroup]="showCreateForm ? createForm : editForm" (ngSubmit)="showCreateForm ? createSong() : editSong()">
+        <!-- Título -->
+        <div class="form-group">
+          <label>Título</label>
+          <input formControlName="title" type="text" />
+        </div>
+
+        <!-- Pública o no -->
+        <div class="form-group">
+          <label>¿Canción pública?</label>
+          <input type="checkbox" formControlName="isPublicSong" />
+        </div>
+
+        <!-- Select artista (solo al crear) -->
+        <div class="form-group" *ngIf="showCreateForm">
+          <label>Artista</label>
+          <select formControlName="artistId">
+            <option value="" disabled selected>Selecciona un artista</option>
+            <option *ngFor="let artist of artists" [value]="artist.id">
+              {{ artist.name }}
+            </option>
+          </select>
+        </div>
+
+        <!-- YouTube -->
+        <div class="form-group">
+          <label>URL de YouTube</label>
+          <input formControlName="youtubeUrl" type="url" />
+        </div>
+
+        <!-- Imagen -->
+        <div class="image-upload-section">
+          <label>Portada:</label>
+          <div class="image-preview">
+            <img *ngIf="previewImageUrl; else placeholder" [src]="previewImageUrl" class="preview-image" />
+            <ng-template #placeholder>
+              <div class="upload-placeholder">
+                <span>📷</span>
+                <p>Sin portada</p>
+              </div>
+            </ng-template>
+            <div class="upload-overlay" *ngIf="uploading">
+              <div class="spinner"></div>
+              <p>Subiendo...</p>
+            </div>
+          </div>
+          <label class="upload-btn">
+            Subir imagen
+            <input type="file" accept="image/*" (change)="onImageSelected($event)" hidden />
+          </label>
+        </div>
+
+        <!-- Botones -->
+        <div class="form-actions">
+          <button class="cancel-btn" type="button" (click)="closeForms()">Cancelar</button>
+          <button class="submit-btn" type="submit" [disabled]="(showCreateForm ? createForm : editForm).invalid">
+            {{ showCreateForm ? 'Crear' : 'Actualizar' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/app/features/admin/pages/admin-songs/admin-songs.component.spec.ts
+++ b/src/app/features/admin/pages/admin-songs/admin-songs.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminSongsComponent } from './admin-songs.component';
+
+describe('AdminSongsComponent', () => {
+  let component: AdminSongsComponent;
+  let fixture: ComponentFixture<AdminSongsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminSongsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminSongsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/admin/pages/admin-songs/admin-songs.component.ts
+++ b/src/app/features/admin/pages/admin-songs/admin-songs.component.ts
@@ -1,0 +1,237 @@
+import { Component, OnInit } from '@angular/core';
+import { SongService } from '../../../../services/Song.service';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { SongResponse, SongRequest } from '../../../../models/song.model';
+import { ArtistService } from '../../../../services/Artist.service';
+import { ArtistResponse } from '../../../../models/artist.model';
+import { FormsModule } from '@angular/forms';
+@Component({
+  selector: 'app-admin-songs',
+  standalone: true,
+  imports: [CommonModule , ReactiveFormsModule, FormsModule ],
+  templateUrl: './admin-songs.component.html',
+  styleUrl: './admin-songs.component.css'
+})
+export class AdminSongsComponent implements OnInit {
+  songs: SongResponse[] = [];
+  artists: ArtistResponse[] = [];
+  loading = false;
+  error = '';
+
+  showCreateForm = false;
+  showEditForm = false;
+  editingSong: SongResponse | null = null;
+
+  createForm: FormGroup;
+  editForm: FormGroup;
+  coverFile: File | null = null;
+  previewImageUrl: string | null = null;
+  uploading = false;
+
+  constructor(
+    private songService: SongService,
+    private artistService: ArtistService,
+    private fb: FormBuilder,
+    private router: Router
+  ) {
+    this.createForm = this.fb.group({
+      title: ['', Validators.required],
+      isPublicSong: [true],
+      artistId: ['', Validators.required],
+      youtubeUrl: [''],
+      imageUrl: ['']
+    });
+
+    this.editForm = this.fb.group({
+      title: ['', Validators.required],
+      isPublicSong: [true],
+      youtubeUrl: [''],
+      imageUrl: ['']
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadAllSongs();
+    this.loadAllArtists();
+  }
+
+  loadAllSongs(): void {
+  this.loading = true;
+  this.songService.getAllSongs().subscribe({
+    next: (data) => {
+      this.songs = data;
+      this.sortSongs(); // 🔁 Ordenar con el valor actual del filtro
+      this.loading = false;
+    },
+    error: () => {
+      this.error = 'Error al cargar las canciones';
+      this.loading = false;
+    }
+  });
+}
+
+  loadAllArtists(): void {
+    this.artistService.getAllArtists().subscribe({
+      next: (data) => {
+        this.artists = data;
+      },
+      error: () => {
+        alert('Error al cargar artistas');
+      }
+    });
+  }
+
+  goBack() {
+    this.router.navigate(['/admin']);
+  }
+
+  openCreateForm() {
+    this.showCreateForm = true;
+    this.createForm.reset({ isPublicSong: true });
+    this.previewImageUrl = null;
+    this.coverFile = null;
+  }
+
+  openEditForm(song: SongResponse) {
+    this.editingSong = song;
+    this.editForm.patchValue({
+      title: song.title,
+      isPublicSong: song.isPublicSong,
+      youtubeUrl: song.youtubeUrl,
+      imageUrl: song.imageUrl || ''
+    });
+    this.previewImageUrl = song.imageUrl || null;
+    this.coverFile = null;
+    this.showEditForm = true;
+  }
+
+  closeForms() {
+    this.showCreateForm = false;
+    this.showEditForm = false;
+    this.editingSong = null;
+    this.previewImageUrl = null;
+    this.coverFile = null;
+  }
+
+  onImageSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files?.[0]) return;
+
+    const file = input.files[0];
+    this.coverFile = file;
+
+    const reader = new FileReader();
+    reader.onload = (e: any) => {
+      this.previewImageUrl = e.target.result;
+    };
+    reader.readAsDataURL(file);
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('upload_preset', 'zuko_pfps');
+
+    this.uploading = true;
+    fetch('https://api.cloudinary.com/v1_1/dqk8inmwe/image/upload', {
+      method: 'POST',
+      body: formData
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        this.uploading = false;
+        if (data.secure_url) {
+          if (this.showEditForm && this.editingSong) {
+            this.editingSong.imageUrl = data.secure_url;
+            this.editForm.patchValue({ imageUrl: data.secure_url });
+          } else {
+            this.createForm.patchValue({ imageUrl: data.secure_url });
+          }
+        } else {
+          alert('Error al subir la imagen');
+        }
+      })
+      .catch(() => {
+        this.uploading = false;
+        alert('Error al subir la imagen');
+      });
+  }
+
+  createSong() {
+    if (this.createForm.valid) {
+      this.loading = true;
+      const data: SongRequest = this.createForm.value;
+      this.songService.createSong(data).subscribe({
+        next: () => {
+          this.loadAllSongs();
+          this.closeForms();
+          this.loading = false;
+        },
+        error: () => {
+          this.loading = false;
+          alert('Error al crear canción');
+        }
+      });
+    }
+  }
+
+  editSong() {
+    if (this.editingSong && this.editForm.valid) {
+      this.loading = true;
+      const data: SongRequest = {
+        ...this.editForm.value,
+        artistId: this.editingSong.artistId
+      };
+      this.songService.updateSong(this.editingSong.id, data).subscribe({
+        next: () => {
+          this.loadAllSongs();
+          this.closeForms();
+          this.loading = false;
+        },
+        error: () => {
+          this.loading = false;
+          alert('Error al actualizar canción');
+        }
+      });
+    }
+  }
+
+  deleteSong(id: number) {
+    if (confirm('¿Estás seguro de eliminar esta canción?')) {
+      this.loading = true;
+      this.songService.deleteSong(id).subscribe({
+        next: () => {
+          this.loadAllSongs();
+          this.loading = false;
+        },
+        error: () => {
+          this.loading = false;
+          alert('Error al eliminar canción');
+        }
+      });
+    }
+  }
+
+  getImageUrl(imageUrl?: string): string {
+    return imageUrl?.trim()
+      ? imageUrl
+      : 'https://res.cloudinary.com/dqk8inmwe/image/upload/v1750800568/pfp_placeholder_hwwumb.jpg';
+  }
+
+  selectedSort: string = 'newest';
+
+  sortSongs(): void {
+    switch (this.selectedSort) {
+      case 'newest':
+        this.songs.sort((a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime());
+        break;
+      case 'oldest':
+        this.songs.sort((a, b) => new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime());
+        break;
+      case 'title':
+        this.songs.sort((a, b) => a.title.localeCompare(b.title));
+        break;
+    }
+}
+
+}

--- a/src/app/services/Song.service.ts
+++ b/src/app/services/Song.service.ts
@@ -39,4 +39,8 @@ export class SongService {
     return this.api.get<SongResponse>(`/songs/${id}`);
   }
 
+  getAllSongs(): Observable<SongResponse[]> {
+  return this.api.get<SongResponse[]>('/songs/all');
+  }
+
 }


### PR DESCRIPTION
Se implementa el componente AdminSongsComponent, accesible desde el dashboard del administrador, que permite:

Ver la lista de canciones

Crear nuevas canciones (incluye subida de portada y selección de artista)

Editar y eliminar canciones existentes

Filtrar canciones por fecha o visibilidad (públicas/privadas)
También se actualizaron las rutas y el servicio de canciones.