### PR TITLE
Feat:  Sección de nuevos lanzamientos del día en el home

### DIFF
--- a/src/app/features/home/home-page.component.css
+++ b/src/app/features/home/home-page.component.css
@@ -1,1 +1,162 @@
 @import url("../playlist/pages/biblioteca/biblioteca.component.css");
+
+.carousel-banner {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, #ffe6e6, #fff5f5);
+  padding: 2rem;
+  border-radius: 16px;
+  margin-bottom: 2rem;
+  min-height: 220px; /* asegura espacio del banner */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.carousel-slider {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+/* Separamos los banners con posicionamiento absoluto pero dejamos espacio en el padre */
+.banner-content {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  padding: 1rem 2rem;
+  opacity: 0;
+  transform: translateX(100%);
+  transition: transform 0.6s ease-in-out, opacity 0.6s ease-in-out;
+}
+
+/* Cuando está activo */
+.slide-in-left,
+.slide-in-right {
+  opacity: 1;
+}
+
+.slide-in-left {
+  animation: slideFromLeft 0.6s forwards;
+}
+
+.slide-in-right {
+  animation: slideFromRight 0.6s forwards;
+}
+
+@keyframes slideFromLeft {
+  from {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+}
+
+@keyframes slideFromRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+}
+
+.banner-content img {
+  width: 180px;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 3px solid #B71C1C;
+}
+
+.banner-text {
+  max-width: 400px;
+}
+
+.new-label {
+  font-weight: 700;
+  color: #B71C1C;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.new-release-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: #000;
+}
+
+.artist-name {
+  color: #555;
+  font-style: italic;
+}
+
+.subtitle {
+  font-size: 0.9rem;
+  color: #888;
+  margin: 0.5rem 0;
+}
+
+.play-btn {
+  background: #B71C1C;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  margin-top: 0.5rem;
+  transition: background 0.3s ease;
+}
+
+.play-btn:hover {
+  background: #8B0000;
+}
+
+.carousel-controls {
+  position: absolute;
+  top: 50%;
+  width: 100%;
+  transform: translateY(-50%);
+  display: flex;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.carousel-btn {
+  pointer-events: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+  color: white;
+  border: none;
+  font-size: 2rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  z-index: 10;
+}
+
+.carousel-btn:hover {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.carousel-btn.prev {
+  margin-left: 0.5rem;
+}
+
+.carousel-btn.next {
+  margin-right: 0.5rem;
+}
+
+.hidden {
+  display: none;
+}

--- a/src/app/features/home/home-page.component.html
+++ b/src/app/features/home/home-page.component.html
@@ -1,4 +1,41 @@
 <div class="library-container">
+
+<!-- 🔔 Nuevo Lanzamiento (Carrusel) -->
+<div class="carousel-banner" *ngIf="latestSongsToday.length > 0">
+  <div class="carousel-slider">
+    <div
+      class="banner-content"
+      *ngFor="let song of latestSongsToday; let i = index"
+      [class.slide-in-left]="i === currentSongIndex && slideDirection === 'left'"
+      [class.slide-in-right]="i === currentSongIndex && slideDirection === 'right'"
+      [class.hidden]="i !== currentSongIndex"
+    >
+      <img class="banner-image" [src]="song.imageUrl" alt="Portada de la canción" />
+      <div class="banner-text">
+        <div class="new-label">🎉 NUEVO LANZAMIENTO</div>
+        <div class="new-release-title">{{ song.title }}</div>
+        <div class="artist-name">por {{ song.artistName }}</div>
+        <div class="subtitle">¡Escucha lo nuevo de {{ song.artistName }}!</div>
+        
+        <button class="play-btn" style="margin-left: 0.5rem" (click)="goToSong(song.id)">
+          Ver canción
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 🔁 Controles -->
+  <div class="carousel-controls" *ngIf="latestSongsToday.length > 1">
+    <button class="carousel-btn prev" (click)="prevBanner()">‹</button>
+    <button class="carousel-btn next" (click)="nextBanner()">›</button>
+  </div>
+
+  <!-- 🎬 YouTube player oculto -->
+  <div style="display: none">
+    <div id="yt-player-detail"></div>
+  </div>
+</div>
+
 <h1 class="shortcut-title">Accesos directos</h1>
 
 <div class="library-tabs">
@@ -26,4 +63,3 @@
             </div>
         </div>
     </div>
-</div>

--- a/src/app/features/home/home-page.component.ts
+++ b/src/app/features/home/home-page.component.ts
@@ -1,10 +1,12 @@
 import { ShortcutsService } from './../../services/shortcuts.service';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { ShortcutsResponse } from '../../models/shortcuts.model';
 import { PlaylistSummaryResponse } from './../../models/playlist.model';
 import { AlbumResponse } from '../../models/album.model';
+import { SongService } from '../../services/Song.service';
+import { SongResponse } from '../../models/song.model';
 
 @Component({
   standalone: true,
@@ -13,21 +15,122 @@ import { AlbumResponse } from '../../models/album.model';
   templateUrl: './home-page.component.html',
   styleUrl: './home-page.component.css'
 })
-export class HomePageComponent implements OnInit {
+export class HomePageComponent implements OnInit{
   shortcuts: ShortcutsResponse[] = [];
   playlists: PlaylistSummaryResponse[] = [];
   albums : AlbumResponse[] = []; // actualizar  
   userId: number | null = null;
   shortcutsId: number | null = null;
   error = '';
+  latestSongsToday: SongResponse[] = [];
+  currentSongIndex = 0;
+  playerRef: any = null;
+  isPlaying = false;
+  private bannerInterval: any;
   isLoading = false;
+  isPlayerReady = false;
+  slideDirection: 'left' | 'right' = 'right';
+
   constructor(private router: Router,
-              private shortcutsService: ShortcutsService
+              private shortcutsService: ShortcutsService,
+              private songService: SongService
   ){}
 
   ngOnInit(): void {
     this.loadShortcuts();
+    this.loadLatestSongsToday();
+
+    setInterval(() => {
+    if (this.latestSongsToday.length > 0) {
+      this.slideDirection = 'right';
+      this.nextBanner();
+    }
+  }, 15000);
   }
+
+
+  loadLatestSongsToday(): void {
+    this.songService.getTop3PublicSongsToday().subscribe({
+      next: (songs) => {
+        this.latestSongsToday = songs;
+        if (songs.length > 0) {
+          const videoId = this.extractVideoId(songs[0].youtubeUrl);
+          this.initYouTubePlayer(videoId);
+        }
+      },
+      error: (err) => {
+        console.error('Error al cargar canciones del día', err);
+      }
+    });
+  }
+
+  extractVideoId(url: string): string {
+    const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    return match ? match[1] : '';
+  }
+
+  initYouTubePlayer(videoId: string): void {
+  this.isPlayerReady = false;
+  this.isPlaying = false;
+
+  if (this.playerRef && this.playerRef.destroy) {
+    this.playerRef.destroy();
+  }
+
+  setTimeout(() => {
+      this.playerRef = new (window as any).YT.Player('yt-player-detail', {
+        videoId,
+        height: '0',
+        width: '0',
+        events: {
+          onReady: () => {
+            this.isPlayerReady = true;
+            console.log('Player ready');
+          },
+          onError: (error: any) => {
+            console.error('Error en reproductor de YouTube:', error);
+          }
+        }
+      });
+    }, 100);
+}
+
+  togglePlay(): void {
+  if (!this.playerRef || !this.isPlayerReady) {
+    console.warn('El reproductor aún no está listo');
+    return;
+  }
+
+  if (this.isPlaying) {
+    this.playerRef.pauseVideo();
+    this.isPlaying = false;
+  } else {
+    this.playerRef.seekTo(0);
+    this.playerRef.playVideo();
+    this.isPlaying = true;
+  }
+}
+
+  nextBanner(): void {
+  if (this.latestSongsToday.length === 0) return;
+  this.slideDirection = 'right';
+  this.currentSongIndex = (this.currentSongIndex + 1) % this.latestSongsToday.length;
+  const videoId = this.extractVideoId(this.latestSongsToday[this.currentSongIndex].youtubeUrl);
+  this.initYouTubePlayer(videoId);
+}
+
+ prevBanner(): void {
+  if (this.latestSongsToday.length === 0) return;
+  this.slideDirection = 'left';
+  this.currentSongIndex =
+    (this.currentSongIndex - 1 + this.latestSongsToday.length) % this.latestSongsToday.length;
+  const videoId = this.extractVideoId(this.latestSongsToday[this.currentSongIndex].youtubeUrl);
+  this.initYouTubePlayer(videoId);
+}
+
+goToSong(songId: number): void {
+  this.router.navigate(['/songs/detail', songId]);
+}
 
   loadShortcuts(): void {
     this.isLoading = true;
@@ -46,13 +149,9 @@ export class HomePageComponent implements OnInit {
       }
     });
   }
-  
-  
 
   goToPlaylist(playlistId: number) {
      this.router.navigate(['/playlist', playlistId]);
   }
-
-
 
 }

--- a/src/app/services/Song.service.ts
+++ b/src/app/services/Song.service.ts
@@ -40,7 +40,10 @@ export class SongService {
   }
 
   getAllSongs(): Observable<SongResponse[]> {
-  return this.api.get<SongResponse[]>('/songs/all');
+    return this.api.get<SongResponse[]>('/songs/all');
   }
 
+  getTop3PublicSongsToday(): Observable<SongResponse[]> {
+    return this.api.get<SongResponse[]>('/songs/top3-today');
+  }
 }


### PR DESCRIPTION
Este Pull Request introduce una nueva sección en la página principal (`HomePage`) que muestra hasta 3 canciones públicas lanzadas en el día actual.

### Cambios principales:
- 🎵 Sección "Nuevo Lanzamiento" integrada en la vista inicial.
- 📦 Consumo del endpoint `getTop3PublicSongsToday` desde `SongService`.
- 🖼️ Visualización de título, artista y portada de la canción destacada.
- ▶️ Botón para reproducir la canción desde YouTube (embed oculto).
- 🔁 Posibilidad de navegar entre lanzamientos si hay más de uno.

### Objetivo:
Destacar las canciones más recientes disponibles al público para mejorar el descubrimiento musical dentro de la plataforma.

---

> ✅ Incluye validaciones para que solo se muestre la sección si existen canciones del día.