### PR TITLE
Actualizar favicon de Zuko y mostrar opción 'Agregar a Playlist' en perfil de otros artistas

### DIFF
--- a/src/app/features/song/pages/artist-songs/artist-songs.component.html
+++ b/src/app/features/song/pages/artist-songs/artist-songs.component.html
@@ -45,11 +45,11 @@
         </div>
 
       <!-- Acciones solo si es su perfil -->
-      <div class="actions" *ngIf="isOwnProfile">
+      <div class="actions">
         <button (click)="toggleMenu(i)" class="menu-button" title="Opciones">&#8942;</button>
         <div *ngIf="openMenuIndex === i" class="dropdown-menu">
-          <button (click)="openEditForm(song)">Editar canción</button>
-          <button (click)="confirmDelete(song)">Eliminar canción</button>
+          <button *ngIf="isOwnProfile" (click)="openEditForm(song)">Editar canción</button>
+          <button *ngIf="isOwnProfile" (click)="confirmDelete(song)">Eliminar canción</button>
           <button (click)="openAddToPlaylist(song)">Agregar a Playlist</button>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>ZukoFrontend</title>
+  <title>ZukoApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/png" href="https://res.cloudinary.com/dqk8inmwe/image/upload/v1750643396/a721a41b-f518-4a2b-a654-b563fb5fc824-removebg-preview_kfp2pc.png">
   <link href="https://fonts.googleapis.com/css2?family=Manjari:wght@700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
Este PR realiza dos mejoras visuales:

- Se reemplazó el logo de Angular default por el logo de Zuko

- Se permitió mostrar el botón de "Agregar a Playlist" en el perfil de otros artistas, incluso si no es el dueño de la canción.