### PR TITLE
feat(album): permitir añadir cualquier canción de un álbum a playlists

### DIFF
--- a/src/app/features/album/pages/album-detail-page/album-detail-page.component.css
+++ b/src/app/features/album/pages/album-detail-page/album-detail-page.component.css
@@ -279,3 +279,33 @@ tr.playing {
     opacity: 0.95;
 }
 
+/* Botón para añadir canción a playlist */
+.add-to-playlist-btn {
+  background: #550000;            
+  color: #fff;
+  border: none;
+  border-radius: 18px;            
+  font-family: 'Manjari', sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  padding: 7px 18px;
+  margin-left: 8px;
+  cursor: pointer;
+  transition: background 0.18s, box-shadow 0.16s;
+  box-shadow: 0 2px 8px rgba(185,0,0,0.07);
+  outline: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.add-to-playlist-btn:hover,
+.add-to-playlist-btn:focus {
+  background: #b90000;
+  box-shadow: 0 3px 12px rgba(183,28,28,0.15);
+}
+
+.add-to-playlist-btn:active {
+  background: #550000;
+}
+

--- a/src/app/features/album/pages/album-detail-page/album-detail-page.component.html
+++ b/src/app/features/album/pages/album-detail-page/album-detail-page.component.html
@@ -42,6 +42,7 @@
         <th>#</th>
         <th>Título</th>
         <th>Fecha de lanzamiento</th>
+        <th></th>
         <th class="play-col"></th>
       </tr>
     </thead>
@@ -54,6 +55,14 @@
         </td>
         <td class="release-date">
           {{ song.releaseDate ? (song.releaseDate | date:'MMM dd, yyyy') : '' }}
+        </td>
+        <td>
+          <button 
+            class="add-to-playlist-btn" 
+            (click)="openAddToPlaylist(song)"
+            title="Añadir a playlist">
+            Añadir a playlist
+          </button>
         </td>
         <td class="play-col">
           <button 
@@ -83,4 +92,11 @@
     (close)="closeDeleteModal()"
     (albumDeleted)="onAlbumDeleted()"
   ></app-delete-album-modal>
+
+  <app-add-song-to-playlist-modal
+    *ngIf="showAddToPlaylistModal && selectedSongForPlaylist"
+    [songId]="selectedSongForPlaylist.id"
+    (close)="onCloseAddToPlaylist()"
+    (songAdded)="onSongAddedToPlaylist()">
+  </app-add-song-to-playlist-modal>
 </div>

--- a/src/app/features/album/pages/album-detail-page/album-detail-page.component.ts
+++ b/src/app/features/album/pages/album-detail-page/album-detail-page.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { AlbumOptionsPopupComponent } from '../../components/album-options-popup/album-options-popup.component';
 import { EditAlbumModalComponent } from '../../components/edit-album-modal/edit-album-modal.component';
 import { DeleteAlbumModalComponent } from '../../components/delete-album-modal/delete-album-modal.component';
+import { AddSongToPlaylistModalComponent } from '../../../playlist/components/agregar-cancion-playlist/add-song-to-playlist.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AlbumService } from '../../../../services/Album.service';
 import { MusicPlayerService } from '../../../../services/music-player.service';
@@ -10,6 +11,7 @@ import { ShortcutsService } from '../../../../services/shortcuts.service';
 import { firstValueFrom } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { UserResponse } from '../../../../models/user.model';
+import { SongResponse } from '../../../../models/song.model';
 
 // Interfaz para la respuesta de accesos directos
 interface ShortcutsResponse {
@@ -37,7 +39,8 @@ interface Song {
     CommonModule, 
     AlbumOptionsPopupComponent, 
     EditAlbumModalComponent, 
-    DeleteAlbumModalComponent
+    DeleteAlbumModalComponent,
+    AddSongToPlaylistModalComponent
   ],
   templateUrl: './album-detail-page.component.html',
   styleUrls: ['./album-detail-page.component.css']
@@ -160,6 +163,10 @@ export class AlbumDetailPageComponent implements OnInit {
   get shouldShowPauseInPlayButton(): boolean {
     return this.isPlaying && this.isCurrentSongFromThisAlbum;
   }
+
+  // Propiedades para añadir canciones a playlists
+  selectedSongForPlaylist: SongResponse | null = null;
+  showAddToPlaylistModal = false;
 
   constructor(
     private route: ActivatedRoute, 
@@ -350,5 +357,34 @@ export class AlbumDetailPageComponent implements OnInit {
         }
       });
     });
+  }
+
+  // Métodos para añadir canciones a playlists
+  openAddToPlaylist(song: Song) {
+    // Convertir Song a SongResponse para compatibilidad
+    this.selectedSongForPlaylist = {
+      id: song.id,
+      title: song.title || song.name || '',
+      artistId: song.artistId || this.album?.artistId || 0,
+      artistName: song.artistName || this.album?.artistName || '',
+      youtubeUrl: song.youtubeUrl,
+      imageUrl: song.imageUrl || this.album?.cover || '',
+      releaseDate: song.releaseDate || '',
+      isPublicSong: song.isPublicSong !== undefined ? song.isPublicSong : true
+    } as SongResponse;
+    
+    this.showAddToPlaylistModal = true;
+  }
+
+  onCloseAddToPlaylist() {
+    this.showAddToPlaylistModal = false;
+    this.selectedSongForPlaylist = null;
+  }
+
+  onSongAddedToPlaylist() {
+    this.showAddToPlaylistModal = false;
+    this.selectedSongForPlaylist = null;
+    // Opcional: mostrar mensaje de éxito
+    console.log('Canción añadida a playlist(s) exitosamente');
   }
 }


### PR DESCRIPTION
- Se agregó un botón "Añadir a playlist" para cada canción en el detalle de álbum.
- Se integró el modal de selección de playlists (add-song-to-playlist).
- Ahora es posible agregar canciones de cualquier álbum a cualquier playlist,sin restricciones.

Closes #70 